### PR TITLE
[Feature/741] Added a Metadata Service to Handle Open Graph Link Previews

### DIFF
--- a/src/app/about-page/about-page.component.ts
+++ b/src/app/about-page/about-page.component.ts
@@ -1,5 +1,5 @@
 import { Component } from "@angular/core";
-import { Title } from "@angular/platform-browser";
+import { MetadataService } from "../services/metadata.service";
 
 @Component({
 	selector: "app-about-page",
@@ -7,7 +7,7 @@ import { Title } from "@angular/platform-browser";
 	styleUrls: ["./about-page.component.css"]
 })
 export class AboutPageComponent {
-	constructor(private titleService: Title) {
-		this.titleService.setTitle("Myneworm - About");
+	constructor(private metaService: MetadataService) {
+		this.metaService.updateMetaTags("About", "/about");
 	}
 }

--- a/src/app/book-page/book-page.component.ts
+++ b/src/app/book-page/book-page.component.ts
@@ -1,8 +1,9 @@
 import { Component, OnInit } from "@angular/core";
-import { Title } from "@angular/platform-browser";
+import { Title, Meta } from "@angular/platform-browser";
 import { ActivatedRoute } from "@angular/router";
 import { BookData } from "../models/bookData";
 import { PublisherData } from "../models/publisherData";
+import { MetadataService } from "../services/metadata.service";
 import { MynewormAPIService } from "../services/myneworm-api.service";
 import { UtilitiesService } from "../services/utilities.service";
 
@@ -18,15 +19,20 @@ export class BookPageComponent implements OnInit {
 	constructor(
 		private route: ActivatedRoute,
 		private service: MynewormAPIService,
-		private titleService: Title,
-		public utilities: UtilitiesService
+		public utilities: UtilitiesService,
+		private metaService: MetadataService
 	) {}
 
 	ngOnInit(): void {
 		this.route.params.subscribe((data) => {
 			this.service.getByISBN(data.isbn).subscribe((data: BookData) => {
 				this.book = data;
-				this.titleService.setTitle(`Myneworm - ${this.book.title}`);
+				this.metaService.updateMetaTags(
+					this.book.title,
+					`/book/${this.book.isbn}`,
+					this.book.description,
+					this.service.getAsset(`${this.book.isbn}`)
+				);
 
 				this.service.getPublisher(data.publisher_id.toString()).subscribe((pubData: PublisherData) => {
 					this.publisher = pubData;

--- a/src/app/book-page/book-page.component.ts
+++ b/src/app/book-page/book-page.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit } from "@angular/core";
-import { Title, Meta } from "@angular/platform-browser";
 import { ActivatedRoute } from "@angular/router";
 import { BookData } from "../models/bookData";
 import { PublisherData } from "../models/publisherData";

--- a/src/app/contact-page/contact-page.component.ts
+++ b/src/app/contact-page/contact-page.component.ts
@@ -1,6 +1,6 @@
 import { Component, ViewChild } from "@angular/core";
-import { Title } from "@angular/platform-browser";
 import { userContactForm } from "src/app/models/userContactForm";
+import { MetadataService } from "../services/metadata.service";
 
 @Component({
 	selector: "app-contact-page",
@@ -12,8 +12,8 @@ export class ContactPageComponent {
 	@ViewChild("userContact") dataForm: any;
 	contactForm = new userContactForm();
 
-	constructor(private titleService: Title) {
-		this.titleService.setTitle("Myneworm - Contact");
+	constructor(private metaService: MetadataService) {
+		this.metaService.updateMetaTags("Contact", "/contact");
 	}
 
 	resetForm() {

--- a/src/app/data-correction-form/data-correction-form.component.ts
+++ b/src/app/data-correction-form/data-correction-form.component.ts
@@ -1,8 +1,8 @@
 import { Component, ViewChild } from "@angular/core";
-import { Title } from "@angular/platform-browser";
 import { ActivatedRoute } from "@angular/router";
 import { BookType } from "../models/BookType";
 import { dataCorrectionForm } from "../models/dataCorrectionForm";
+import { MetadataService } from "../services/metadata.service";
 import { MynewormAPIService } from "../services/myneworm-api.service";
 import { UtilitiesService } from "../services/utilities.service";
 
@@ -22,9 +22,9 @@ export class DataCorrectionFormComponent {
 		private route: ActivatedRoute,
 		private service: MynewormAPIService,
 		private utilities: UtilitiesService,
-		private titleService: Title
+		private metaService: MetadataService
 	) {
-		this.titleService.setTitle("Myneworm - Data Correction");
+		this.metaService.updateMetaTags("Data Correction", "/correction");
 
 		this.route.queryParams.subscribe((data) => {
 			this.correction.isbn = data.isbn;

--- a/src/app/faq-page/faq-page.component.ts
+++ b/src/app/faq-page/faq-page.component.ts
@@ -1,6 +1,6 @@
 import { Component } from "@angular/core";
 import { FAQData } from "./faqData";
-import { Title } from "@angular/platform-browser";
+import { MetadataService } from "../services/metadata.service";
 
 @Component({
 	selector: "app-faq-page",
@@ -10,7 +10,7 @@ import { Title } from "@angular/platform-browser";
 export class FaqPageComponent {
 	faqData = FAQData;
 
-	constructor(private titleService: Title) {
-		this.titleService.setTitle("Myneworm - FAQ");
+	constructor(private metaService: MetadataService) {
+		this.metaService.updateMetaTags("FAQ", "/faq");
 	}
 }

--- a/src/app/home-page/home-page.component.ts
+++ b/src/app/home-page/home-page.component.ts
@@ -4,13 +4,13 @@ import { MynewormAPIService } from "../services/myneworm-api.service";
 import { CalendarManagerComponent } from "../shared/calendar-manager/calendar-manager.component";
 import { MatDialog, MatDialogConfig } from "@angular/material/dialog";
 import { DatepickerModalComponent } from "../shared/datepicker-modal/datepicker-modal.component";
-import { Title } from "@angular/platform-browser";
 import { UtilitiesService } from "../services/utilities.service";
 import { MonthDateFetcher } from "../classes/MonthDateFetcher.class";
 import { CalendarOptions } from "@fullcalendar/core";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import interactionPlugin from "@fullcalendar/interaction";
 import listPlugin from "@fullcalendar/list";
+import { MetadataService } from "../services/metadata.service";
 
 /*
  * Global file values as CalendarOptions does not accept `this` keyword
@@ -35,10 +35,10 @@ export class HomePageComponent implements OnInit {
 		private route: ActivatedRoute,
 		private service: MynewormAPIService,
 		public matDialog: MatDialog,
-		private titleService: Title,
+		private metaService: MetadataService,
 		private utilities: UtilitiesService
 	) {
-		this.titleService.setTitle("Myneworm - Home");
+		this.metaService.updateMetaTags("Home", "/");
 		dateFetcher = new MonthDateFetcher(this.service, this.utilities);
 
 		formatCSS = this.utilities.formatCSSClass;

--- a/src/app/imprint-index/imprint-index.component.ts
+++ b/src/app/imprint-index/imprint-index.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { MynewormAPIService } from "../services/myneworm-api.service";
 import { ImprintData } from "../models/imprintData";
-import { Title } from "@angular/platform-browser";
+import { MetadataService } from "../services/metadata.service";
 
 @Component({
 	selector: "app-imprint-index",
@@ -12,8 +12,12 @@ import { Title } from "@angular/platform-browser";
 export class ImprintIndexComponent implements OnInit {
 	imprints: ImprintData[];
 
-	constructor(private route: ActivatedRoute, private service: MynewormAPIService, private titleService: Title) {
-		this.titleService.setTitle("Myneworm - Imprint List");
+	constructor(
+		private route: ActivatedRoute,
+		private service: MynewormAPIService,
+		private metaService: MetadataService
+	) {
+		this.metaService.updateMetaTags("Imprint List", "/publisher");
 	}
 
 	ngOnInit() {

--- a/src/app/imprint-page/imprint-page.component.ts
+++ b/src/app/imprint-page/imprint-page.component.ts
@@ -6,11 +6,11 @@ import { CalendarManagerComponent } from "../shared/calendar-manager/calendar-ma
 import { MatDialog, MatDialogConfig } from "@angular/material/dialog";
 import { DatepickerModalComponent } from "../shared/datepicker-modal/datepicker-modal.component";
 import { ImprintData } from "../models/imprintData";
-import { Title } from "@angular/platform-browser";
 import { UtilitiesService } from "../services/utilities.service";
 import { ImprintBookFetcher } from "../classes/ImprintBookFetcher.class";
 import interactionPlugin from "@fullcalendar/interaction";
 import listPlugin from "@fullcalendar/list";
+import { MetadataService } from "../services/metadata.service";
 
 /*
  * Global file values as CalendarOptions does not accept `this` keyword
@@ -36,7 +36,7 @@ export class ImprintPageComponent implements OnInit {
 		private route: ActivatedRoute,
 		private service: MynewormAPIService,
 		public matDialog: MatDialog,
-		private titleService: Title,
+		private metaService: MetadataService,
 		private utilities: UtilitiesService
 	) {
 		imprintFetcher = new ImprintBookFetcher(this.service, this.utilities);
@@ -101,7 +101,12 @@ export class ImprintPageComponent implements OnInit {
 			this.service.getImprintInfo(data.id).subscribe((data: ImprintData) => {
 				this.imprint = data;
 				publisher = data;
-				this.titleService.setTitle(`Myneworm - ${this.imprint.name}`);
+				this.metaService.updateMetaTags(
+					this.imprint.name,
+					`/publisher/${this.imprint.publisher_id}`,
+					undefined,
+					this.getLogo(this.imprint.publisher_id)
+				);
 			});
 		});
 	}

--- a/src/app/missing-page/missing-page.component.ts
+++ b/src/app/missing-page/missing-page.component.ts
@@ -1,5 +1,5 @@
 import { Component } from "@angular/core";
-import { Title } from "@angular/platform-browser";
+import { MetadataService } from "../services/metadata.service";
 
 @Component({
 	selector: "app-missing-page",
@@ -7,7 +7,7 @@ import { Title } from "@angular/platform-browser";
 	styleUrls: ["./missing-page.component.css"]
 })
 export class MissingPageComponent {
-	constructor(private titleService: Title) {
-		this.titleService.setTitle("Myneworm - 404 Not Found");
+	constructor(private metaService: MetadataService) {
+		this.metaService.resetMetaTags("404 Not Found");
 	}
 }

--- a/src/app/services/metadata.service.spec.ts
+++ b/src/app/services/metadata.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from "@angular/core/testing";
+
+import { MetadataService } from "./metadata.service";
+
+describe("MetadataService", () => {
+	let service: MetadataService;
+
+	beforeEach(() => {
+		TestBed.configureTestingModule({});
+		service = TestBed.inject(MetadataService);
+	});
+
+	it("should be created", () => {
+		expect(service).toBeTruthy();
+	});
+});

--- a/src/app/services/metadata.service.ts
+++ b/src/app/services/metadata.service.ts
@@ -1,0 +1,55 @@
+import { Injectable } from "@angular/core";
+import { Title, Meta } from "@angular/platform-browser";
+
+@Injectable({
+	providedIn: "root"
+})
+export class MetadataService {
+	private setImage = false;
+
+	constructor(private titleService: Title, private metaService: Meta) {}
+
+	updateMetaTags(title: string, path: string, description?: string, imageURL?: string) {
+		this.titleService.setTitle(`Myneworm - ${title}`);
+		this.metaService.updateTag({ name: "og:title", content: `Myneworm - ${title}` });
+		this.metaService.updateTag({ name: "og:url", content: `https://myneworm.katsurin.com${path}` });
+
+		if (description) {
+			this.metaService.updateTag({ name: "description", content: description });
+			this.metaService.updateTag({ name: "og:description", content: description });
+		} else {
+			this.metaService.updateTag({
+				name: "description",
+				content: "Track and stay up-to-date on upcoming light novel and manga releases"
+			});
+			this.metaService.updateTag({
+				name: "og:description",
+				content: "Track and stay up-to-date on upcoming light novel and manga releases"
+			});
+		}
+
+		if (imageURL) {
+			this.metaService.addTag({ name: "og:image", content: `https://myneworm.katsurin.com${imageURL}` });
+			this.setImage = true;
+		} else if (this.setImage) {
+			this.metaService.removeTag("name='og:image'");
+			this.setImage = false;
+		}
+	}
+
+	resetMetaTags(title: string) {
+		this.titleService.setTitle(`Myneworm - ${title}`);
+		this.metaService.updateTag({ name: "og:title", content: `Myneworm - ${title}` });
+		this.metaService.updateTag({ name: "og:url", content: `https://myneworm.katsurin.com` });
+		this.metaService.updateTag({
+			name: "description",
+			content: "Track and stay up-to-date on upcoming light novel and manga releases"
+		});
+		this.metaService.updateTag({
+			name: "og:description",
+			content: "Track and stay up-to-date on upcoming light novel and manga releases"
+		});
+		this.metaService.removeTag("name='og:image'");
+		this.setImage = false;
+	}
+}

--- a/src/app/services/metadata.service.ts
+++ b/src/app/services/metadata.service.ts
@@ -29,7 +29,7 @@ export class MetadataService {
 		}
 
 		if (imageURL) {
-			this.metaService.addTag({ name: "og:image", content: `https://myneworm.katsurin.com${imageURL}` });
+			this.metaService.addTag({ name: "og:image", content: imageURL });
 			this.setImage = true;
 		} else if (this.setImage) {
 			this.metaService.removeTag("name='og:image'");

--- a/src/index.html
+++ b/src/index.html
@@ -8,6 +8,12 @@
   <title>Myneworm</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="og:title" content="Myneworm">
+  <meta name="og:description" content="Track and stay up-to-date on upcoming light novel and manga releases">
+  <meta name="og:site_name" content="Myneworm">
+  <meta name="og:locale" content="en">
+  <meta name="og:type" content="website">
+  <meta name="og:url" content="https://myneworm.katsurin.com">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">


### PR DESCRIPTION
## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Adds more meta tags with focus in Open Graph for link previews to have dynamic data instead of a generic title and description. 

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

Created a metadata service to manage all of the Open Graph tags as well as the regular meta tags and the title. Then, updated all of the current components to utilize the new service and removed the title service from them.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->

Internal#741