### PR TITLE
[Fix/743] Added Error Redirect for 404 Data Error

### DIFF
--- a/src/app/book-page/book-page.component.ts
+++ b/src/app/book-page/book-page.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
+import { catchError } from "rxjs";
 import { BookData } from "../models/bookData";
 import { PublisherData } from "../models/publisherData";
 import { MetadataService } from "../services/metadata.service";
@@ -24,19 +25,26 @@ export class BookPageComponent implements OnInit {
 
 	ngOnInit(): void {
 		this.route.params.subscribe((data) => {
-			this.service.getByISBN(data.isbn).subscribe((data: BookData) => {
-				this.book = data;
-				this.metaService.updateMetaTags(
-					this.book.title,
-					`/book/${this.book.isbn}`,
-					this.book.description,
-					this.service.getAsset(`${this.book.isbn}`)
-				);
+			this.service
+				.getByISBN(data.isbn)
+				.pipe(catchError((err) => this.utilities.catchAPIError(err)))
+				.subscribe((data: BookData | null) => {
+					if (data === null) {
+						return;
+					}
 
-				this.service.getPublisher(data.publisher_id.toString()).subscribe((pubData: PublisherData) => {
-					this.publisher = pubData;
+					this.book = data;
+					this.metaService.updateMetaTags(
+						this.book.title,
+						`/book/${this.book.isbn}`,
+						this.book.description,
+						this.service.getAsset(`${this.book.isbn}`)
+					);
+
+					this.service.getPublisher(data.publisher_id.toString()).subscribe((pubData: PublisherData) => {
+						this.publisher = pubData;
+					});
 				});
-			});
 		});
 	}
 

--- a/src/app/imprint-page/imprint-page.component.ts
+++ b/src/app/imprint-page/imprint-page.component.ts
@@ -11,6 +11,7 @@ import { ImprintBookFetcher } from "../classes/ImprintBookFetcher.class";
 import interactionPlugin from "@fullcalendar/interaction";
 import listPlugin from "@fullcalendar/list";
 import { MetadataService } from "../services/metadata.service";
+import { catchError } from "rxjs";
 
 /*
  * Global file values as CalendarOptions does not accept `this` keyword
@@ -98,16 +99,22 @@ export class ImprintPageComponent implements OnInit {
 		this.calendarVisible = true;
 
 		this.route.params.subscribe((data) => {
-			this.service.getImprintInfo(data.id).subscribe((data: ImprintData) => {
-				this.imprint = data;
-				publisher = data;
-				this.metaService.updateMetaTags(
-					this.imprint.name,
-					`/publisher/${this.imprint.publisher_id}`,
-					undefined,
-					this.getLogo(this.imprint.publisher_id)
-				);
-			});
+			this.service
+				.getImprintInfo(data.id)
+				.pipe(catchError((err) => this.utilities.catchAPIError(err)))
+				.subscribe((data: ImprintData | null) => {
+					if (data === null) {
+						return;
+					}
+					this.imprint = data;
+					publisher = data;
+					this.metaService.updateMetaTags(
+						this.imprint.name,
+						`/publisher/${this.imprint.publisher_id}`,
+						undefined,
+						this.getLogo(this.imprint.publisher_id)
+					);
+				});
 		});
 	}
 

--- a/src/app/services/utilities.service.ts
+++ b/src/app/services/utilities.service.ts
@@ -1,9 +1,13 @@
 import { Injectable } from "@angular/core";
+import { Router } from "@angular/router";
+import { of } from "rxjs";
 
 @Injectable({
 	providedIn: "root"
 })
 export class UtilitiesService {
+	constructor(private router: Router) {}
+
 	dateFormater(year: number, month: number) {
 		let result = `${year}`;
 		if (month < 10) {
@@ -68,5 +72,17 @@ export class UtilitiesService {
 		}
 
 		return result;
+	}
+
+	/* Handle the error catching for pages */
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	catchAPIError(error: any) {
+		if (error.status === 404) {
+			this.router.navigate(["/404"]);
+		} else {
+			console.error(error);
+		}
+
+		return of(null);
 	}
 }


### PR DESCRIPTION
## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Added an error catch function to the book and imprint page and a utility function to handle errors. If there is a 404 status, the pages will redirect to the 404 page while more unknown errors will error out in the console for support purposes.

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

Updated the utility service with an API error catching function and then updated the book and imprint page components to use the new function with pipe.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->

Internal#743