### PR TITLE
[Feature/721] Added Search Page

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -10,6 +10,7 @@ import { FaqPageComponent } from "./faq-page/faq-page.component";
 import { AboutPageComponent } from "./about-page/about-page.component";
 import { DataCorrectionFormComponent } from "./data-correction-form/data-correction-form.component";
 import { ContactPageComponent } from "./contact-page/contact-page.component";
+import { SearchPageComponent } from "./search-page/search-page.component";
 
 const routes: Routes = [
 	{ path: "", component: HomePageComponent },
@@ -18,6 +19,7 @@ const routes: Routes = [
 	{ path: "publisher", component: ImprintIndexComponent },
 	{ path: "publisher/:id", component: ImprintPageComponent },
 	{ path: "series/:id", component: SeriesPageComponent },
+	{ path: "search", component: SearchPageComponent },
 	{ path: "about", component: AboutPageComponent },
 	{ path: "faq", component: FaqPageComponent },
 	{ path: "correction", component: DataCorrectionFormComponent },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -19,6 +19,8 @@ import { SearchBarModule } from "./search-bar/search-bar.module";
 import { DataCorrectionFormComponent } from "./data-correction-form/data-correction-form.component";
 import { ContactPageComponent } from "./contact-page/contact-page.component";
 import { MatDialogModule } from "@angular/material/dialog";
+import { SearchPageComponent } from "./search-page/search-page.component";
+import { SearchPageModule } from "./search-page/search-page.module";
 
 @NgModule({
 	declarations: [
@@ -42,6 +44,7 @@ import { MatDialogModule } from "@angular/material/dialog";
 		ImprintIndexModule,
 		SeriesPageModule,
 		SearchBarModule,
+		SearchPageModule,
 		MatDialogModule
 	],
 	providers: [Title],

--- a/src/app/search-bar/search-bar.component.html
+++ b/src/app/search-bar/search-bar.component.html
@@ -2,7 +2,7 @@
     <form #searchInput="ngForm" (ngSubmit)="submit()">
         <input type="text" class="search-input" placeholder="Search" [(ngModel)]="searchTerm" #userInput="ngModel" [ngModelOptions]="{standalone: true}"
             [ngClass]="{'no-radius-bottom-left' : this.dataSource.data.length > 0 || (this.dataSource.data.length === 0 && this.searchTerm !== '')}" (input)="onChange()" />
-        <button type="submit" class="search-submit" 
+        <button type="submit" class="search-submit" (click)="onButtonClick()"
             [ngClass]="{'no-radius-bottom-right' : this.dataSource.data.length > 0 || (this.dataSource.data.length === 0 && this.searchTerm !== '')}"
             aria-label="Search">
                 <img class="search-btn-icon" src="../../assets/fa-search.svg" alt="Search icon"/>

--- a/src/app/search-bar/search-bar.component.ts
+++ b/src/app/search-bar/search-bar.component.ts
@@ -56,6 +56,13 @@ export class SearchBarComponent {
 		this.resetData();
 	}
 
+	onButtonClick() {
+		this.router.navigate(["/search"], {
+			queryParams: { term: this.searchTerm }
+		});
+		this.resetData();
+	}
+
 	mouseOverRow(row: BookData) {
 		this.hoveredRow = row;
 	}

--- a/src/app/search-page/search-page.component.css
+++ b/src/app/search-page/search-page.component.css
@@ -1,0 +1,119 @@
+.search-page {
+    width: 98%;
+    margin-left: 1%;
+    margin-right: 1%;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    flex-direction: column;
+}
+
+.search-results {
+    background-color: #ECEBF3;
+}
+
+.search-cover-img {
+    max-height: 100px;
+}
+
+.mat-column-cover {
+    width: 100px;
+    height: 100px;
+    padding-top: 4px;
+    padding-bottom: 4px;
+}
+
+.mat-column-format {
+    width: 110px;
+    text-align: center;
+    padding-left: 8px;
+    padding-right: 8px;
+}
+
+.mat-column-type {
+    width: 100px;
+    text-align: center;
+    padding-left: 8px;
+    padding-right: 8px;
+}
+
+.search-form {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.search-input-long {
+    padding-top: 4px;
+    padding-bottom: 4px;
+    outline-width: 0;
+    height: 46px;
+    border: solid;
+    border-radius: 8px 0 0 8px;
+    border-color: #1F2232;
+    border-right: solid;
+    padding-left: 1em;
+    width: 50%;
+    border-width: 2px 1px 2px 2px;
+}
+
+.search-submit-long {
+    height: 58px;
+    padding: 1px 4px 0 6px;
+    background-color: #fff;
+    border: solid;
+    display: flex;
+    align-items: center;
+    border-color: #1F2232;
+    border-radius: 0 6px 6px 0;
+    border-left: none;
+    border-width: 2px;
+}
+
+.search-btn-icon-long {
+    height: 44px;
+}
+
+.search-page-header {
+    margin-bottom: 0;
+}
+
+.search-page-line {
+    margin-top: 0.2%;
+}
+
+.search-page-message {
+    padding-left: 1em;
+}
+
+.search-item-title {
+    margin-bottom: 10px;
+    margin-top: 4px;
+}
+
+.search-item-desc {
+    margin-bottom: 10px;
+    margin-top: 0;
+}
+
+.search-link {
+    color: #0D98BA;
+    text-decoration: none;
+}
+
+.search-link:hover {
+    text-decoration: underline;
+}
+
+.line-clamp {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
+    -webkit-box-orient: vertical;  
+}
+
+@media (max-width: 800px) {
+    .line-clamp {
+        -webkit-line-clamp: 3;
+    }
+}

--- a/src/app/search-page/search-page.component.css
+++ b/src/app/search-page/search-page.component.css
@@ -8,9 +8,21 @@
     flex-direction: column;
 }
 
-.search-results {
-    background-color: #ECEBF3;
+.search-bar-large {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-evenly;
+    align-items: center;
 }
+
+.search-inner-div {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    width: 75%;
+}
+
+.advanced-options-button {}
 
 .search-cover-img {
     max-height: 100px;
@@ -34,13 +46,20 @@
     width: 100px;
     text-align: center;
     padding-left: 8px;
-    padding-right: 8px;
+    padding-right: 16px;
 }
 
 .search-form {
     display: flex;
+    justify-content: flex-end;
+    width: 100%;
+}
+
+.search-div {
+    display: flex;
+    flex-direction: column;
     align-items: center;
-    justify-content: center;
+    width: 50%;
 }
 
 .search-input-long {
@@ -53,8 +72,8 @@
     border-color: #1F2232;
     border-right: solid;
     padding-left: 1em;
-    width: 50%;
     border-width: 2px 1px 2px 2px;
+    width: 100%;
 }
 
 .search-submit-long {
@@ -103,6 +122,14 @@
 
 .search-link:hover {
     text-decoration: underline;
+}
+
+.search-result-row, .search-result-row:hover {
+    background-color: #ECEBF3;
+}
+
+.search-result-row:nth-child(2n), .search-result-row:nth-child(2n):hover {
+    background-color: #fff;
 }
 
 .line-clamp {

--- a/src/app/search-page/search-page.component.css
+++ b/src/app/search-page/search-page.component.css
@@ -22,7 +22,17 @@
     width: 75%;
 }
 
-.advanced-options-button {}
+.advanced-options-button {
+    margin-top: 8px;
+}
+
+.advanced-options-button > a {
+    color: #0D98BA;
+}
+
+.hide-adv-options {
+    display: none;
+}
 
 .search-cover-img {
     max-height: 100px;
@@ -87,6 +97,17 @@
     border-radius: 0 6px 6px 0;
     border-left: none;
     border-width: 2px;
+    cursor: pointer;
+}
+
+.search-pagination {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.search-pagination > a {
+    margin-right: 10px;
+    color: #0D98BA;
 }
 
 .search-btn-icon-long {
@@ -130,6 +151,10 @@
 
 .search-result-row:nth-child(2n), .search-result-row:nth-child(2n):hover {
     background-color: #fff;
+}
+
+.no-page {
+    display: none;
 }
 
 .line-clamp {

--- a/src/app/search-page/search-page.component.html
+++ b/src/app/search-page/search-page.component.html
@@ -13,7 +13,7 @@
                     </button>
                 </form>
                 <div class="advanced-options-button">
-                    <p>Advanced Options</p>
+                    <a href="javascript:void(0)" class="clickable-button" (click)="onAdvOptionsClick()">Advanced Options</a>
                 </div>
             </div>
         </div>
@@ -26,6 +26,10 @@
     <div class="search-results">
         <h3 class="search-page-header">Search Results</h3>
         <hr class="search-page-line">
+        <div class="search-pagination">
+            <a href="javascript:void(0)" [ngClass]="this.pageNumber == 1 ? 'no-page' : ''" (click)="prevPage()">< Previous</a>
+            <a href="javascript:void(0)" [ngClass]="this.dataSource.filteredData.length === 0 || this.dataSource.filteredData.length < 25 ? 'no-page' : ''" (click)="nextPage()">Next ></a>
+        </div>        
         <table *ngIf="dataSource" mat-table [dataSource]="dataSource" multiTemplateDataRows class="search-results">
             <ng-container matColumnDef="cover">
                 <td class="search-image-row" mat-cell *matCellDef="let element">
@@ -51,8 +55,7 @@
                     <p>{{this.utilities.formatReadable(element.book_type_name)}}</p>
                 </td>
             </ng-container>
-            <tr mat-row *matRowDef="let row; columns: displayedColumns" class="search-result-row"
-                (mouseenter)="mouseOverRow(row)" (mouseleave)="mouseLeaveRow()"></tr>
+            <tr mat-row *matRowDef="let row; columns: displayedColumns" class="search-result-row"></tr>
             <tr class="mat-row search-result-row" *matNoDataRow
                 [ngClass]="this.searchTerm !== '' ? '' : 'hide-no-result'">
                 <td class="mat-cell" [attr.colspan]="displayedColumns.length">

--- a/src/app/search-page/search-page.component.html
+++ b/src/app/search-page/search-page.component.html
@@ -1,16 +1,24 @@
 <div class="search-page">
     <div class="search-bar-large">
-        <form #searchInput="ngForm" (ngSubmit)="submit()" class="search-form">
-            <input type="text" class="search-input-long" placeholder="Search" [(ngModel)]="searchTerm" #userInput="ngModel" [ngModelOptions]="{standalone: true}"
-                [ngClass]="{'no-radius-bottom-left' : this.dataSource.data.length > 0 || (this.dataSource.data.length === 0 && this.searchTerm !== '')}" />
-            <button type="submit" class="search-submit-long" 
-                [ngClass]="{'no-radius-bottom-right' : this.dataSource.data.length > 0 || (this.dataSource.data.length === 0 && this.searchTerm !== '')}"
-                aria-label="Search">
-                    <img class="search-btn-icon-long" src="../../assets/fa-search.svg" alt="Search icon"/>
-            </button>
-        </form>
+        <div class="search-div">
+            <div class="search-inner-div">
+                <form #searchInput="ngForm" (ngSubmit)="submit()" class="search-form">
+                    <input type="text" class="search-input-long" placeholder="Search" [(ngModel)]="searchTerm"
+                        #userInput="ngModel" [ngModelOptions]="{standalone: true}"
+                        [ngClass]="{'no-radius-bottom-left' : this.dataSource.data.length > 0 || (this.dataSource.data.length === 0 && this.searchTerm !== '')}" />
+                    <button type="submit" class="search-submit-long"
+                        [ngClass]="{'no-radius-bottom-right' : this.dataSource.data.length > 0 || (this.dataSource.data.length === 0 && this.searchTerm !== '')}"
+                        aria-label="Search">
+                        <img class="search-btn-icon-long" src="../../assets/fa-search.svg" alt="Search icon" />
+                    </button>
+                </form>
+                <div class="advanced-options-button">
+                    <p>Advanced Options</p>
+                </div>
+            </div>
+        </div>
     </div>
-    <div class="advanced-options">
+    <div class="advanced-options" [ngClass]="{ 'hide-adv-options': !showAdvancedOptions }">
         <h3 class="search-page-header">Advanced Options</h3>
         <hr class="search-page-line">
         <p>Coming soon...</p>
@@ -21,12 +29,14 @@
         <table *ngIf="dataSource" mat-table [dataSource]="dataSource" multiTemplateDataRows class="search-results">
             <ng-container matColumnDef="cover">
                 <td class="search-image-row" mat-cell *matCellDef="let element">
-                    <a routerLink="/book/{{element.isbn}}"><img class="search-cover-img" src='{{this.service.getAsset(element.isbn)}}' alt='Cover for {{element.title}}' /></a>
+                    <a routerLink="/book/{{element.isbn}}"><img class="search-cover-img"
+                            src='{{this.service.getAsset(element.isbn)}}' alt='Cover for {{element.title}}' /></a>
                 </td>
             </ng-container>
             <ng-container matColumnDef="title">
                 <td class="search-text-row" mat-cell *matCellDef="let element">
-                    <h4 class="search-item-title"><strong><a routerLink="/book/{{element.isbn}}" class="search-link">{{element.title}}</a></strong></h4>
+                    <h4 class="search-item-title"><strong><a routerLink="/book/{{element.isbn}}"
+                                class="search-link">{{element.title}}</a></strong></h4>
                     <p class="search-item-desc line-clamp" [innerHTML]="element.description"></p>
                     <span class="more"><a routerLink="/book/{{element.isbn}}" class="search-link">Read more</a></span>
                 </td>
@@ -41,30 +51,15 @@
                     <p>{{this.utilities.formatReadable(element.book_type_name)}}</p>
                 </td>
             </ng-container>
-            <tr mat-row *matRowDef="let row; columns: displayedColumns" class="search-result-row" 
+            <tr mat-row *matRowDef="let row; columns: displayedColumns" class="search-result-row"
                 (mouseenter)="mouseOverRow(row)" (mouseleave)="mouseLeaveRow()"></tr>
-            <tr class="mat-row search-result-row" *matNoDataRow [ngClass]="this.searchTerm !== '' ? '' : 'hide-no-result'">
+            <tr class="mat-row search-result-row" *matNoDataRow
+                [ngClass]="this.searchTerm !== '' ? '' : 'hide-no-result'">
                 <td class="mat-cell" [attr.colspan]="displayedColumns.length">
                     <strong>
                         <p class="search-page-message">No results found...</p>
                     </strong>
                 </td>
-            </tr>
-            <tr>
-                <th>Cover</th>
-                <th>Title</th>
-                <th>Format</th>
-                <th>Book Type</th>
-            </tr>
-            <tr>
-                <td>Alfreds Futterkiste</td>
-                <td>Maria Anders</td>
-                <td>Germany</td>
-            </tr>
-            <tr>
-                <td>Centro comercial Moctezuma</td>
-                <td>Francisco Chang</td>
-                <td>Mexico</td>
             </tr>
         </table>
     </div>

--- a/src/app/search-page/search-page.component.html
+++ b/src/app/search-page/search-page.component.html
@@ -1,0 +1,71 @@
+<div class="search-page">
+    <div class="search-bar-large">
+        <form #searchInput="ngForm" (ngSubmit)="submit()" class="search-form">
+            <input type="text" class="search-input-long" placeholder="Search" [(ngModel)]="searchTerm" #userInput="ngModel" [ngModelOptions]="{standalone: true}"
+                [ngClass]="{'no-radius-bottom-left' : this.dataSource.data.length > 0 || (this.dataSource.data.length === 0 && this.searchTerm !== '')}" />
+            <button type="submit" class="search-submit-long" 
+                [ngClass]="{'no-radius-bottom-right' : this.dataSource.data.length > 0 || (this.dataSource.data.length === 0 && this.searchTerm !== '')}"
+                aria-label="Search">
+                    <img class="search-btn-icon-long" src="../../assets/fa-search.svg" alt="Search icon"/>
+            </button>
+        </form>
+    </div>
+    <div class="advanced-options">
+        <h3 class="search-page-header">Advanced Options</h3>
+        <hr class="search-page-line">
+        <p>Coming soon...</p>
+    </div>
+    <div class="search-results">
+        <h3 class="search-page-header">Search Results</h3>
+        <hr class="search-page-line">
+        <table *ngIf="dataSource" mat-table [dataSource]="dataSource" multiTemplateDataRows class="search-results">
+            <ng-container matColumnDef="cover">
+                <td class="search-image-row" mat-cell *matCellDef="let element">
+                    <a routerLink="/book/{{element.isbn}}"><img class="search-cover-img" src='{{this.service.getAsset(element.isbn)}}' alt='Cover for {{element.title}}' /></a>
+                </td>
+            </ng-container>
+            <ng-container matColumnDef="title">
+                <td class="search-text-row" mat-cell *matCellDef="let element">
+                    <h4 class="search-item-title"><strong><a routerLink="/book/{{element.isbn}}" class="search-link">{{element.title}}</a></strong></h4>
+                    <p class="search-item-desc line-clamp" [innerHTML]="element.description"></p>
+                    <span class="more"><a routerLink="/book/{{element.isbn}}" class="search-link">Read more</a></span>
+                </td>
+            </ng-container>
+            <ng-container matColumnDef="format">
+                <td class="search-format-col" mat-cell *matCellDef="let element">
+                    <p>{{this.utilities.formatReadable(element.format_name)}}</p>
+                </td>
+            </ng-container>
+            <ng-container matColumnDef="type">
+                <td class="search-type-col" mat-cell *matCellDef="let element">
+                    <p>{{this.utilities.formatReadable(element.book_type_name)}}</p>
+                </td>
+            </ng-container>
+            <tr mat-row *matRowDef="let row; columns: displayedColumns" class="search-result-row" 
+                (mouseenter)="mouseOverRow(row)" (mouseleave)="mouseLeaveRow()"></tr>
+            <tr class="mat-row search-result-row" *matNoDataRow [ngClass]="this.searchTerm !== '' ? '' : 'hide-no-result'">
+                <td class="mat-cell" [attr.colspan]="displayedColumns.length">
+                    <strong>
+                        <p class="search-page-message">No results found...</p>
+                    </strong>
+                </td>
+            </tr>
+            <tr>
+                <th>Cover</th>
+                <th>Title</th>
+                <th>Format</th>
+                <th>Book Type</th>
+            </tr>
+            <tr>
+                <td>Alfreds Futterkiste</td>
+                <td>Maria Anders</td>
+                <td>Germany</td>
+            </tr>
+            <tr>
+                <td>Centro comercial Moctezuma</td>
+                <td>Francisco Chang</td>
+                <td>Mexico</td>
+            </tr>
+        </table>
+    </div>
+</div>

--- a/src/app/search-page/search-page.component.spec.ts
+++ b/src/app/search-page/search-page.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+
+import { SearchPageComponent } from "./search-page.component";
+
+describe("SearchPageComponent", () => {
+	let component: SearchPageComponent;
+	let fixture: ComponentFixture<SearchPageComponent>;
+
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+			declarations: [SearchPageComponent]
+		}).compileComponents();
+
+		fixture = TestBed.createComponent(SearchPageComponent);
+		component = fixture.componentInstance;
+		fixture.detectChanges();
+	});
+
+	it("should create", () => {
+		expect(component).toBeTruthy();
+	});
+});

--- a/src/app/search-page/search-page.component.ts
+++ b/src/app/search-page/search-page.component.ts
@@ -1,0 +1,44 @@
+import { Component } from "@angular/core";
+import { MatTableDataSource } from "@angular/material/table";
+import { ActivatedRoute } from "@angular/router";
+import { BookData } from "../models/bookData";
+import { MetadataService } from "../services/metadata.service";
+import { MynewormAPIService } from "../services/myneworm-api.service";
+import { UtilitiesService } from "../services/utilities.service";
+
+@Component({
+	selector: "search-page",
+	templateUrl: "./search-page.component.html",
+	styleUrls: ["./search-page.component.css"]
+})
+export class SearchPageComponent {
+	displayedColumns = ["cover", "title", "format", "type"];
+	searchTerm = "";
+	public dataSource: MatTableDataSource<BookData> = new MatTableDataSource<BookData>();
+
+	constructor(
+		private route: ActivatedRoute,
+		public service: MynewormAPIService,
+		public utilities: UtilitiesService,
+		private metaService: MetadataService
+	) {
+		this.metaService.updateMetaTags("Search", "/search");
+	}
+
+	private searchBooks() {
+		if (this.searchTerm === "") {
+			return;
+		}
+		this.service.searchBooksWithLimit(this.searchTerm, 25, 1).subscribe((data: BookData[]) => {
+			this.dataSource = new MatTableDataSource<BookData>(data);
+		});
+	}
+
+	submit() {
+		this.searchBooks();
+	}
+
+	mouseOverRow(row: BookData) {}
+
+	mouseLeaveRow() {}
+}

--- a/src/app/search-page/search-page.component.ts
+++ b/src/app/search-page/search-page.component.ts
@@ -15,6 +15,8 @@ export class SearchPageComponent {
 	displayedColumns = ["cover", "title", "format", "type"];
 	searchTerm = "";
 	public dataSource: MatTableDataSource<BookData> = new MatTableDataSource<BookData>();
+	hoveredRow: BookData | null = null;
+	showAdvancedOptions = false;
 
 	constructor(
 		private route: ActivatedRoute,
@@ -38,7 +40,11 @@ export class SearchPageComponent {
 		this.searchBooks();
 	}
 
-	mouseOverRow(row: BookData) {}
+	mouseOverRow(row: BookData) {
+		this.hoveredRow = row;
+	}
 
-	mouseLeaveRow() {}
+	mouseLeaveRow() {
+		this.hoveredRow = null;
+	}
 }

--- a/src/app/search-page/search-page.module.ts
+++ b/src/app/search-page/search-page.module.ts
@@ -1,0 +1,25 @@
+import { NgModule } from "@angular/core";
+import { BrowserModule } from "@angular/platform-browser";
+import { SearchPageComponent } from "./search-page.component";
+import { FormsModule, ReactiveFormsModule } from "@angular/forms";
+import { MatButtonModule } from "@angular/material/button";
+import { MatFormFieldModule } from "@angular/material/form-field";
+import { MatInputModule } from "@angular/material/input";
+import { MatTableModule } from "@angular/material/table";
+import { RouterModule } from "@angular/router";
+
+@NgModule({
+	declarations: [SearchPageComponent],
+	imports: [
+		BrowserModule,
+		FormsModule,
+		ReactiveFormsModule,
+		MatButtonModule,
+		MatFormFieldModule,
+		MatInputModule,
+		MatTableModule,
+		RouterModule
+	],
+	exports: [SearchPageComponent]
+})
+export class SearchPageModule {}

--- a/src/app/services/myneworm-api.service.ts
+++ b/src/app/services/myneworm-api.service.ts
@@ -53,6 +53,17 @@ export class MynewormAPIService {
 		return this.http.get<BookData[]>(`${environment.API_ADDRESS}/book/search?term=${term}&limit=10`);
 	}
 
+	searchBooksWithLimit(term: string, limit: number, page?: number) {
+		if (page === undefined || page < 1) {
+			page = 1;
+		}
+		if (limit === undefined || limit < 1) {
+			limit = 10;
+		}
+
+		return this.http.get<BookData[]>(`${environment.API_ADDRESS}/book/search/${page}?term=${term}&limit=${limit}`);
+	}
+
 	searchBooks(publisherID?: string, startDate?: string, endDate?: string) {
 		let params = "";
 		let multipleParams = false;


### PR DESCRIPTION
## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Added a search page for users to see more results and use pages to flip through multiple batches of results.

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

Created a search page component and set up the router to access the new component at `/search`. The component was designed and the basic functionality was implemented with term searching and pages. Users can also navigate to a specific results using query parameters (ie: `/search?term=Bookworm&page=2`).

A section for advanced options was laid out but not implemented at this time. A new ticket will be made for that as the API needs some more work on search before it can be built.

The search bar was also updated to direct to the search page on submit and show the results page on load.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->

Internal#721