### PR TITLE
[Fix/754] Fixed OG Meta Tags From Name to Property Key

### DIFF
--- a/src/app/services/metadata.service.ts
+++ b/src/app/services/metadata.service.ts
@@ -11,45 +11,45 @@ export class MetadataService {
 
 	updateMetaTags(title: string, path: string, description?: string, imageURL?: string) {
 		this.titleService.setTitle(`Myneworm - ${title}`);
-		this.metaService.updateTag({ name: "og:title", content: `Myneworm - ${title}` });
-		this.metaService.updateTag({ name: "og:url", content: `https://myneworm.katsurin.com${path}` });
+		this.metaService.updateTag({ property: "og:title", content: `Myneworm - ${title}` });
+		this.metaService.updateTag({ property: "og:url", content: `https://myneworm.katsurin.com${path}` });
 
 		if (description) {
 			this.metaService.updateTag({ name: "description", content: description });
-			this.metaService.updateTag({ name: "og:description", content: description });
+			this.metaService.updateTag({ property: "og:description", content: description });
 		} else {
 			this.metaService.updateTag({
 				name: "description",
 				content: "Track and stay up-to-date on upcoming light novel and manga releases"
 			});
 			this.metaService.updateTag({
-				name: "og:description",
+				property: "og:description",
 				content: "Track and stay up-to-date on upcoming light novel and manga releases"
 			});
 		}
 
 		if (imageURL) {
-			this.metaService.addTag({ name: "og:image", content: imageURL });
+			this.metaService.addTag({ property: "og:image", content: imageURL });
 			this.setImage = true;
 		} else if (this.setImage) {
-			this.metaService.removeTag("name='og:image'");
+			this.metaService.removeTag("property='og:image'");
 			this.setImage = false;
 		}
 	}
 
 	resetMetaTags(title: string) {
 		this.titleService.setTitle(`Myneworm - ${title}`);
-		this.metaService.updateTag({ name: "og:title", content: `Myneworm - ${title}` });
-		this.metaService.updateTag({ name: "og:url", content: `https://myneworm.katsurin.com` });
+		this.metaService.updateTag({ property: "og:title", content: `Myneworm - ${title}` });
+		this.metaService.updateTag({ property: "og:url", content: `https://myneworm.katsurin.com` });
 		this.metaService.updateTag({
 			name: "description",
 			content: "Track and stay up-to-date on upcoming light novel and manga releases"
 		});
 		this.metaService.updateTag({
-			name: "og:description",
+			property: "og:description",
 			content: "Track and stay up-to-date on upcoming light novel and manga releases"
 		});
-		this.metaService.removeTag("name='og:image'");
+		this.metaService.removeTag("property='og:image'");
 		this.setImage = false;
 	}
 }

--- a/src/index.html
+++ b/src/index.html
@@ -8,12 +8,12 @@
   <title>Myneworm</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="og:title" content="Myneworm">
-  <meta name="og:description" content="Track and stay up-to-date on upcoming light novel and manga releases">
-  <meta name="og:site_name" content="Myneworm">
-  <meta name="og:locale" content="en">
-  <meta name="og:type" content="website">
-  <meta name="og:url" content="https://myneworm.katsurin.com">
+  <meta property="og:title" content="Myneworm">
+  <meta property="og:description" content="Track and stay up-to-date on upcoming light novel and manga releases">
+  <meta property="og:site_name" content="Myneworm">
+  <meta property="og:locale" content="en">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://myneworm.katsurin.com">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="preconnect" href="https://fonts.gstatic.com">
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">


### PR DESCRIPTION
<!-- 
    Thank you for contributing! 
    If you have not already, please review the contribution guidelines before submitting:
    https://github.com/Butterstroke/Myneworm/tree/master/.github/CONTRIBUTING.md
-->

## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Fixes the link previews as the Open Graph meta tags were using a name key and not a property key.

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

Updated both the main HTML and the metadata service to use property keys.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->

Internal#754