### PR TITLE
[Spike/785] Added Privacy Policy

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -11,6 +11,7 @@ import { AboutPageComponent } from "./about-page/about-page.component";
 import { DataCorrectionFormComponent } from "./data-correction-form/data-correction-form.component";
 import { ContactPageComponent } from "./contact-page/contact-page.component";
 import { SearchPageComponent } from "./search-page/search-page.component";
+import { PrivacyPageComponent } from "./privacy-page/privacy-page.component";
 
 const routes: Routes = [
 	{ path: "", component: HomePageComponent },
@@ -24,6 +25,7 @@ const routes: Routes = [
 	{ path: "faq", component: FaqPageComponent },
 	{ path: "correction", component: DataCorrectionFormComponent },
 	{ path: "contact", component: ContactPageComponent },
+	{ path: "privacy", component: PrivacyPageComponent },
 	{ path: "**", pathMatch: "full", component: MissingPageComponent }
 ];
 

--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -56,7 +56,20 @@ footer span {
     vertical-align: middle;
     display: inline-block;
     line-height: 75px;
+}
+
+footer span:last-child {
     margin-right: 20px;
+}
+
+footer a {
+    color: #ECEBF3;
+    text-decoration: none; 
+}
+
+.footer-seperator {
+    margin-right: 8px;
+    margin-left: 8px;
 }
 
 .nav-li {

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -20,6 +20,8 @@
         <router-outlet></router-outlet>
     </div>
     <footer>
+        <span><a [routerLink]="'/privacy'">Privacy</a></span>
+        <span class="footer-seperator">|</span>
         <span>Myneworm &copy;2022-{{currYear}} Katsurin Studios</span>
     </footer>
 </div>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -19,8 +19,8 @@ import { SearchBarModule } from "./search-bar/search-bar.module";
 import { DataCorrectionFormComponent } from "./data-correction-form/data-correction-form.component";
 import { ContactPageComponent } from "./contact-page/contact-page.component";
 import { MatDialogModule } from "@angular/material/dialog";
-import { SearchPageComponent } from "./search-page/search-page.component";
 import { SearchPageModule } from "./search-page/search-page.module";
+import { PrivacyPageComponent } from "./privacy-page/privacy-page.component";
 
 @NgModule({
 	declarations: [
@@ -45,7 +45,8 @@ import { SearchPageModule } from "./search-page/search-page.module";
 		SeriesPageModule,
 		SearchBarModule,
 		SearchPageModule,
-		MatDialogModule
+		MatDialogModule,
+		PrivacyPageComponent
 	],
 	providers: [Title],
 	bootstrap: [AppComponent]

--- a/src/app/privacy-page/privacy-page.component.css
+++ b/src/app/privacy-page/privacy-page.component.css
@@ -1,0 +1,146 @@
+.privacy-container {
+    margin-left: 2%;
+    margin-right: 2%;
+    margin-top: 1%;
+    margin-bottom: 1%;
+}
+
+.privacy-title {
+    font-family: Arial;
+    font-size: 26px;
+    color: #000000;
+}
+
+.privacy-subtitle {
+    font-family: Arial;
+    color: #595959;
+    font-size: 14px;
+}
+
+.privacy-description {
+    margin-top: 48px;
+    margin-bottom: 48px;
+}
+
+.privacy-h1 {
+    font-family: Arial;
+    font-size: 19px;
+    color: #000000;
+    margin: 0;
+    margin-bottom: 24px;
+}
+
+.privacy-h2 {
+    font-family: Arial;
+    font-size: 17px;
+    color: #000000;
+    margin: 0;
+}
+
+.privacy-header-subtitle {
+    font-family: Arial;
+    font-size: 15px;
+    color: rgb(89, 89, 89);
+}
+
+.body-text {
+    color: #595959 !important;
+    font-size: 14px !important;
+    font-family: Arial !important;
+}
+
+.link {
+    color: #3030F1 !important;
+    font-size: 14px !important;
+    font-family: Arial !important;
+    word-break: break-word !important;
+}
+
+.line-height-15 {
+    line-height: 1.5;
+}
+
+.margin-16 {
+    margin-top: 16px;
+    margin-bottom: 16px;
+}
+
+.margin-left-20 {
+    margin-left: 20px;
+}
+
+.width-100 {
+    width: 100%;
+}
+
+ul {
+    list-style-type: square;
+}
+
+ul>li>ul {
+    list-style-type: circle;
+}
+
+ul>li>ul>li>ul {
+    list-style-type: square;
+}
+
+ol li {
+    font-family: Arial;
+}
+
+.privacy-link {
+    color: #3030F1 !important;
+    font-size: 14px !important;
+    font-family: Arial !important;
+    word-break: break-word !important;
+}
+
+.table-border-center {
+    border-right: 1px solid black; 
+    border-top: 1px solid black;
+    width: 51.4385%;
+}
+
+.table-borders-left {
+    border-left: 1px solid black; 
+    border-right: 1px solid black; 
+    border-top: 1px solid black;
+    width: 33.8274%;
+}
+
+.table-border-right {
+    border-right: 1px solid black; 
+    border-top: 1px solid black;
+    width: 14.9084%; 
+    text-align: center;
+}
+
+.vertical-aline-middle {
+    vertical-align: middle;
+}
+
+.table-border-bottom {
+    border-bottom: 1px solid black;
+}
+
+td:last-child > span {
+    color: rgb(89, 89, 89);
+    font-size: 15px;
+}
+
+.privacy-section-header {
+    color: rgb(0, 0, 0);
+    font-size: 15px;
+}
+
+.privacy-section-div {
+    margin-bottom: 24px;
+}
+
+.termly-footer {
+    color: #595959;
+    font-size: 14px;
+    font-family: Arial;
+    padding-top:16px;
+}

--- a/src/app/privacy-page/privacy-page.component.html
+++ b/src/app/privacy-page/privacy-page.component.html
@@ -1,0 +1,1489 @@
+<div class="privacy-container">
+    <span class="privacy-title">
+        <strong>PRIVACY POLICY</strong>
+    </span>
+    <div><br></div>
+    <span class="privacy-subtitle">
+        <strong>Last updated March 03, 2023</strong>
+    </span>
+    <div class="line-height-15 privacy-description body-text">
+        <span>
+            This privacy notice for Katsurin Studios ('<strong>Company</strong>', '<strong>we</strong>',
+            '<strong>us</strong>', or '<strong>our</strong>'), describes how and why we might collect, store, use,
+            and/or share ('<strong>process</strong>') your information when you use our services
+            ('<strong>Services</strong>'), such as when you:
+        </span>
+        <ul>
+            <li class="margin-16">
+                <span>
+                    Visit our website at
+                    <a href="https://myneworm.katsurin.com" class="privacy-link link"
+                        target="_blank">https://myneworm.katsurin.com</a>,
+                    or any website of ours that links to this privacy notice
+                </span>
+            </li>
+            <li class="margin-16">
+                <span>
+                    Engage with us in other related ways, including any sales, marketing, or events
+                </span>
+            </li>
+        </ul>
+        <span>
+            <strong>Questions or concerns? </strong>
+            Reading this privacy
+            notice will help you understand your privacy rights and choices. If you do not agree with our
+            policies and practices, please do not use our Services. If you still have any questions or
+            concerns, please contact us at fkatsura@katsurin.com.
+        </span>
+    </div>
+    <div id="key-point-summary" class="line-height-15 body-text">
+        <h1 class="privacy-h1">
+            SUMMARY OF KEY POINTS
+        </h1>
+        <span>
+            <strong><em>This summary provides key points from our privacy notice,
+                    but you can find out more details about any of these topics by clicking the link following
+                    each key point or by using our table of contents below to find the section you are looking
+                    for. You can also click <a class="link" href="/privacy#toc">here</a>
+                    to go directly to our table of contents.</em></strong>
+        </span>
+        <div><br></div>
+        <span>
+            <strong>What personal information do we process?</strong>
+            When you visit, use, or navigate our Services, we may process personal information depending on how you
+            interact with Katsurin Studios
+            and the Services, the choices you make, and the products and features you use. Click
+            <a class="link" href="/privacy#personalinfo">here</a> to learn more.
+        </span>
+        <div><br></div>
+        <span>
+            <strong>Do we process any sensitive personal information?</strong>
+            We do not process sensitive personal information.
+        </span>
+        <div><br></div>
+        <span>
+            <strong>Do we receive any information from third parties?</strong> We do not receive any information
+            from third parties.
+        </span>
+        <div><br></div>
+        <span>
+            <strong>How do we process your information?</strong>
+            We process your information to provide, improve, and administer our Services, communicate with you, for
+            security and fraud prevention, and to comply with
+            law. We may also process your information for other purposes with your consent. We process your
+            information only when we have a valid legal reason to do so. Click <a class="link"
+                href="/privacy#infouse">here</a>
+            to learn more.
+        </span>
+        <div><br></div>
+        <span>
+            <strong>In what situations and with which parties do we share personal information?</strong>
+            We may share information in specific situations and with specific third parties. Click
+            <a class="link" href="/privacy#whoshare">here</a> to learn more.
+        </span>
+        <div><br></div>
+        <span>
+            <strong>How do we keep your information safe?</strong>
+            We have organisational and technical processes and procedures in place to
+            protect your personal information. However, no electronic transmission over the internet or
+            information storage technology can be guaranteed to be 100% secure, so we cannot promise or
+            guarantee that hackers, cybercriminals, or other unauthorised third
+            parties will not be able to defeat our security and improperly
+            collect, access, steal, or modify your information. Click <a class="link" href="/privacy#infosafe">here</a>
+            to learn
+            more.
+        </span>
+        <div><br></div>
+        <span>
+            <strong>What are your rights?</strong>
+            Depending on where you are located geographically, the applicable
+            privacy law may mean you have certain rights regarding your personal information.
+            Click <a class="link" href="/privacy#privacyrights">here</a> to learn more.
+        </span>
+        <div><br></div>
+        <span>
+            <strong>How do you exercise your rights?</strong>
+            The easiest way to exercise your rights is by filling out our data subject request form available
+            <a class="link" href="https://app.termly.io/notify/4e2f4038-d2fa-4cab-90ea-ba2981b3cf9d"
+                rel="noopener noreferrer" target="_blank">here</a>, or by contacting us. We will consider and act upon
+            any request in accordance with applicable data protection laws.
+        </span>
+        <div><br></div>
+        <span>
+            Want to learn more about what Katsurin Studios does with any information we collect? Click
+            <a class="link" href="/privacy#toc">here</a> to review the notice in full.
+        </span>
+    </div>
+    <div class="line-height-15"><br><br></div>
+    <div id="toc" class="line-height-15">
+        <h1 class="privacy-h1">
+            TABLE OF CONTENTS
+        </h1>
+        <ol>
+            <li>
+                <a class="privacy-link" data-custom-class="link" href="/privacy#infocollect">
+                    WHAT INFORMATION DO WE COLLECT?
+                </a>
+            </li>
+            <li>
+                <a class="privacy-link" data-custom-class="link" href="/privacy#infouse">HOW DO WE PROCESS YOUR
+                    INFORMATION?</a>
+            </li>
+            <li>
+                <a class="privacy-link" data-custom-class="link" href="/privacy#legalbases">
+                    WHAT LEGAL BASES DO WE RELY ON TO PROCESS YOUR PERSONAL INFORMATION?
+                </a>
+            </li>
+            <li>
+                <a class="privacy-link" data-custom-class="link" href="/privacy#whoshare">
+                    WHEN AND WITH WHOM DO WE SHARE YOUR PERSONAL INFORMATION?
+                </a>
+            </li>
+            <li>
+                <a class="privacy-link" data-custom-class="link" href="/privacy#3pwebsites">
+                    WHAT IS OUR STANCE ON THIRD-PARTY WEBSITES?
+                </a>
+            </li>
+            <li>
+                <a class="privacy-link" data-custom-class="link" href="/privacy#cookies">
+                    DO WE USE COOKIES AND OTHER TRACKING TECHNOLOGIES?
+                </a>
+            </li>
+            <li>
+                <a class="privacy-link" data-custom-class="link" href="/privacy#intltransfers">
+                    IS YOUR INFORMATION TRANSFERRED INTERNATIONALLY?
+                </a>
+            </li>
+            <li>
+                <a class="privacy-link" data-custom-class="link" href="/privacy#inforetain">
+                    HOW LONG DO WE KEEP YOUR INFORMATION?
+                </a>
+            </li>
+            <li>
+                <a class="privacy-link" data-custom-class="link" href="/privacy#infosafe">
+                    HOW DO WE KEEP YOUR INFORMATION SAFE?
+                </a>
+            </li>
+            <li>
+                <a class="privacy-link" data-custom-class="link" href="/privacy#privacyrights">
+                    WHAT ARE YOUR PRIVACY RIGHTS?
+                </a>
+            </li>
+            <li>
+                <a class="privacy-link" data-custom-class="link" href="/privacy#DNT">
+                    CONTROLS FOR DO-NOT-TRACK FEATURES
+                </a>
+            </li>
+            <li>
+                <a class="privacy-link" data-custom-class="link" href="/privacy#caresidents">
+                    DO CALIFORNIA RESIDENTS HAVE SPECIFIC PRIVACY RIGHTS?
+                </a>
+            </li>
+            <li>
+                <a class="privacy-link" data-custom-class="link" href="/privacy#virginia">
+                    DO VIRGINIA RESIDENTS HAVE SPECIFIC PRIVACY RIGHTS?
+                </a>
+            </li>
+            <li>
+                <a class="privacy-link" data-custom-class="link" href="/privacy#policyupdates">
+                    DO WE MAKE UPDATES TO THIS NOTICE?
+                </a>
+            </li>
+            <li>
+                <a class="privacy-link" data-custom-class="link" href="/privacy#contact">
+                    HOW CAN YOU CONTACT US ABOUT THIS NOTICE?
+                </a>
+            </li>
+            <li>
+                <a class="privacy-link" data-custom-class="link" href="/privacy#request">
+                    HOW CAN YOU REVIEW, UPDATE, OR DELETE THE DATA WE COLLECT FROM YOU?
+                </a>
+            </li>
+        </ol>
+    </div>
+    <div class="line-height-15"><br><br></div>
+    <div id="infocollect" class="line-height-15">
+        <h1 class="privacy-h1">
+            1. WHAT INFORMATION DO WE COLLECT?
+        </h1>
+        <div id="personalinfo" class="line-height-15 body-text">
+            <h2 class="privacy-h2">
+                Personal information you disclose to us
+            </h2>
+            <div><br></div>
+            <span class="privacy-header-subtitle">
+                <strong><em>In Short: </em></strong>
+                <em>We collect personal information that you provide to us.</em>
+            </span>
+            <div><br></div>
+            <span>
+                We collect personal information that you voluntarily provide to us when you register on the
+                Services, express an interest in obtaining
+                information about us or our products and Services, when you participate in activities on the
+                Services, or otherwise when you contact us.
+            </span>
+            <div><br></div>
+            <span>
+                <strong>Personal Information Provided by You.</strong>
+                The personal information that we collect depends on the context of your interactions with us and the
+                Services, the choices you make, and the products and features you use. The personal information
+                we collect may include the following:
+            </span>
+            <ul>
+                <li class="margin-16">
+                    <span>email addresses</span>
+                </li>
+                <li class="margin-16">
+                    <span>usernames</span>
+                </li>
+                <li class="margin-16">
+                    <span>passwords</span>
+                </li>
+            </ul>
+        </div>
+        <div id="sensitiveinfo" class="line-height-15 body-text">
+            <span>
+                <strong>Sensitive Information.</strong>
+                We do not process sensitive information.
+            </span>
+            <div><br></div>
+            <span>
+                All personal information that you provide to us must be true, complete, and accurate, and you must
+                notify us of any changes to such personal information.
+            </span>
+        </div>
+        <div><br></div>
+        <div id="automaticinfocollect" class="line-height-15 body-text">
+            <h2 class="privacy-h2">Information automatically collected</h2>
+            <br>
+            <span class="privacy-header-subtitle">
+                <strong><em>In Short: </em></strong>
+                <em>Some information — such as your Internet Protocol (IP) address and/or browser and device
+                    characteristics — is collected automatically when you visit our Services.
+                </em>
+            </span>
+            <div><br></div>
+            <span>
+                We automatically collect certain information when you visit, use, or navigate the Services. This
+                information does not reveal your specific identity (like your name or contact information) but
+                may include device and usage information, such as your IP address, browser and device
+                characteristics, operating system, language preferences, referring URLs, device name, country,
+                location, information about how and when you use our Services, and other technical information.
+                This information is primarily needed to maintain the security and operation of our Services, and
+                for our internal analytics and reporting purposes.
+            </span>
+            <div><br></div>
+            <span>
+                Like many businesses, we also collect information through cookies and similar technologies.
+            </span>
+            <div><br></div>
+            <span>The information we collect includes:</span>
+            <ul>
+                <li class="margin-16">
+                    <span>
+                        <em>Log and Usage Data.</em>
+                        Log and usage data is service-related, diagnostic, usage, and
+                        performance information our servers automatically collect when you access or use our
+                        Services and which we record in log files. Depending on how you interact with us, this log
+                        data may include your IP address, device information, browser type, and settings and
+                        information about your activity in the Services (such
+                        as the date/time stamps associated with your usage, pages and files viewed, searches, and
+                        other actions you take such as which features you use), device event information (such as
+                        system activity, error reports (sometimes called 'crash
+                        dumps'), and hardware settings).
+                    </span>
+                </li>
+                <li class="margin-16">
+                    <span>
+                        <em>Device Data.</em>
+                        We collect device data such as information about your computer, phone,
+                        tablet, or other device you use to access the Services. Depending on the device used, this
+                        device data may include information such as your IP address (or proxy server), device and
+                        application identification numbers, location, browser type, hardware model, Internet service
+                        provider and/or mobile carrier, operating system, and system configuration information.
+                    </span>
+                </li>
+            </ul>
+        </div>
+    </div>
+    <div id="infouse" class="line-height-15 body-text privacy-section-div">
+        <h1 class="privacy-h1" id="control">2. HOW DO WE PROCESS YOUR INFORMATION?</h1>
+        <span class="privacy-header-subtitle">
+            <strong><em>In Short: </em></strong>
+            <em>We process your information to provide, improve, and administer our
+                Services, communicate with you, for security and fraud prevention, and
+                to comply with law. We may also process your information for other
+                purposes with your
+                consent.</em>
+        </span>
+        <div><br></div>
+        <span>
+            <strong>We process your personal information for a variety of reasons, depending on how you
+                interact with our Services, including:</strong>
+        </span>
+        <ul>
+            <li class="margin-16">
+                <span>
+                    <strong>To facilitate account creation and authentication
+                        and otherwise manage user accounts. </strong>We may process your information so you
+                    can create and log in to your account, as well as keep your account in working order.
+                </span>
+            </li>
+            <li class="margin-16">
+                <span>
+                    <strong>To save or protect an individual's vital interest.</strong>
+                    We may process your information when necessary to save or protect an individual’s vital
+                    interest, such as to prevent harm.
+                </span>
+            </li>
+        </ul>
+    </div>
+    <div id="legalbases" class="line-height-15 body-text privacy-section-div">
+        <h1 class="privacy-h1">3. WHAT LEGAL BASES DO WE RELY ON TO PROCESS YOUR INFORMATION?</h1>
+        <span class="privacy-header-subtitle">
+            <em><strong>In Short: </strong>
+                We only process your personal information when we believe it is necessary and we have a
+                valid legal reason (i.e. legal basis) to do so under applicable law, like with your
+                consent, to comply with laws, to provide you with services to enter into or fulfil our
+                contractual obligations, to protect your rights, or to fulfil our legitimate business
+                interests.
+            </em>
+        </span>
+        <div><br></div>
+        <span>
+            <em><strong><u>If you are located in the EU or UK, this section applies to
+                        you.</u></strong></em>
+        </span>
+        <div><br></div>
+        <span>
+            The General Data Protection Regulation (GDPR) and UK GDPR require us to explain the valid legal
+            bases we rely on in order to process your personal information. As such, we may rely on
+            the following legal bases to process your personal information:
+        </span>
+        <ul>
+            <li class="margin-16">
+                <span>
+                    <strong>Consent. </strong>
+                    We may process your information if you have given us permission (i.e. consent) to use your
+                    personal
+                    information for a specific purpose. You can withdraw your consent at any time.
+                    Click <a class="link" href="/privacy#withdrawconsent">here</a> to learn more.
+                </span>
+            </li>
+            <li class="margin-16">
+                <span>
+                    <strong>Legal Obligations.</strong>
+                    We may process your information where we believe it is necessary for compliance with our
+                    legal obligations, such as to cooperate with a law enforcement body or regulatory
+                    agency, exercise or defend our legal rights, or disclose your information as
+                    evidence in litigation in which we are involved.
+                </span>
+            </li>
+            <li class="margin-16">
+                <span>
+                    <strong>Vital Interests.</strong>
+                    We may process your information where we believe it is necessary to protect your vital
+                    interests or the vital interests of a
+                    third party, such as situations involving potential threats to the safety of any person.
+                </span>
+            </li>
+        </ul>
+        <div><br></div>
+        <span>
+            <strong><u><em>If you are located in Canada, this section applies to
+                        you.</em></u></strong>
+        </span>
+        <div><br></div>
+        <span>
+            We may process your information if you have given us specific permission (i.e. express consent) to
+            use your personal information for a specific purpose, or in situations where your permission can
+            be inferred (i.e. implied consent). You can withdraw your consent at any time. Click
+            <a class="link" href="/privacy#withdrawconsent">here</a> to learn more.
+        </span>
+        <div><br></div>
+        <span>
+            In some exceptional cases, we may be legally permitted under applicable law to process
+            your information without your consent, including, for example:
+        </span>
+        <ul>
+            <li class="margin-16">
+                <span>
+                    If collection is clearly in the interests of an individual and consent cannot be
+                    obtained in a timely way
+                </span>
+            </li>
+            <li class="margin-16">
+                <span>
+                    For investigations and fraud detection and prevention
+                </span>
+            </li>
+            <li class="margin-16">
+                <span>
+                    For business transactions provided certain conditions are met
+                </span>
+            </li>
+            <li class="margin-16">
+                <span>
+                    If it is contained in a witness statement and the collection is necessary to assess,
+                    process, or settle an insurance claim
+                </span>
+            </li>
+            <li class="margin-16">
+                <span>
+                    For identifying injured, ill, or deceased persons and communicating with next of kin
+                </span>
+            </li>
+            <li class="margin-16">
+                <span>
+                    If we have reasonable grounds to believe an individual has been, is, or may be
+                    victim of financial abuse
+                </span>
+            </li>
+            <li class="margin-16">
+                <span>
+                    If it is reasonable to expect collection and use with consent would compromise the
+                    availability or the accuracy of the information and the collection
+                    is reasonable for purposes related to investigating a breach of an agreement or a
+                    contravention of the laws of Canada or a province
+                </span>
+            </li>
+            <li class="margin-16">
+                <span>
+                    If disclosure is required to comply with a subpoena, warrant, court order, or rules of
+                    the court relating to the production of records
+                </span>
+            </li>
+            <li class="margin-16">
+                <span>
+                    If it was produced by an individual in the course of their employment, business, or
+                    profession and the collection is consistent with the purposes for which the
+                    information was produced
+                </span>
+            </li>
+            <li class="margin-16">
+                <span>
+                    If the collection is solely for journalistic, artistic, or literary purposes
+                </span>
+            </li>
+            <li class="margin-16">
+                <span>
+                    If the information is publicly available and is specified by the regulations
+                </span>
+            </li>
+        </ul>
+    </div>
+    <div id="whoshare" class="line-height-15 body-text privacy-section-div">
+        <h1 class="privacy-h1" id="control">4. WHEN AND WITH WHOM DO WE SHARE YOUR PERSONAL INFORMATION?</h1>
+        <span class="privacy-header-subtitle">
+            <strong><em>In Short: </em></strong>
+            <em>We may share information in specific situations described in this section and/or
+                with the following third parties.</em>
+        </span>
+        <div><br></div>
+        <span>
+            We may need to share your personal information in the following situations:
+        </span>
+        <ul>
+            <li class="margin-16">
+                <span>
+                    <strong>Business Transfers.</strong>
+                    We may share or transfer your information in connection with, or during negotiations of,
+                    any merger, sale of company assets, financing, or acquisition of all or
+                    a portion of our business to another company.
+                </span>
+            </li>
+        </ul>
+    </div>
+    <div class="line-height-15 body-text privacy-section-div">
+        <h1 id="3pwebsites" class="privacy-h1">5. WHAT IS OUR STANCE ON THIRD-PARTY WEBSITES?</h1>
+        <span class="privacy-header-subtitle">
+            <strong><em>In Short: </em></strong>
+            <em>We are not responsible for the safety of any information that you share with third
+                parties that we may link to or who advertise on our Services, but are not affiliated
+                with, our Services.</em>
+        </span>
+        <div><br></div>
+        <span>
+            The Services may link to third-party websites, online services, or mobile applications
+            and/or contain advertisements from third parties that are not affiliated with us and
+            which may link to other websites, services, or applications. Accordingly, we do not make
+            any guarantee regarding any such third parties, and we will not be liable for any loss
+            or damage caused by the use of such third-party websites, services, or applications.
+            The inclusion of a link towards a third-party website, service, or application does
+            not imply an endorsement by us. We cannot guarantee the safety and privacy of data
+            you provide to any third parties. Any data collected by third parties is not covered by
+            this privacy notice. We are not responsible for the content or privacy and security
+            practices and policies of any third parties, including other websites, services,
+            or applications that may be linked to or from the Services. You should review the
+            policies of such third parties and contact them directly to respond to your questions.
+        </span>
+    </div>
+    <div id="cookies" class="line-height-15 body-text privacy-section-div">
+        <h1 class="privacy-h1" id="control">6. DO WE USE COOKIES AND OTHER TRACKING TECHNOLOGIES?</h1>
+        <span class="privacy-header-subtitle">
+            <strong><em>In Short: </em></strong>
+            <em>We may use cookies and other tracking technologies to collect and store your
+                information.</em>
+        </span>
+        <div><br></div>
+        <span>
+            We may use cookies and similar tracking technologies (like web beacons and pixels) to access or
+            store information. Specific information about how we use such
+            technologies and how you can refuse certain cookies is set out in our Cookie Notice.
+        </span>
+    </div>
+    <div id="intltransfers" class="line-height-15 body-text privacy-section-div">
+        <h1 class="privacy-h1" id="control">7. IS YOUR INFORMATION TRANSFERRED INTERNATIONALLY?</h1>
+        <span class="privacy-header-subtitle">
+            <strong><em>In Short: </em></strong>
+            <em>We may transfer, store, and process your information in countries other than your
+                own.</em>
+        </span>
+        <div><br></div>
+        <span>
+            Our servers are located in Canada, and United States. If you are accessing our Services from outside Canada,
+            and United States, please be aware that your information may be transferred to, stored, and processed by us
+            in our facilities and by those third parties with whom we may share your personal information (see '
+            <a data-custom-class="link" href="/privacy#whoshare">
+                WHEN AND WITH WHOM DO WE SHARE YOUR PERSONAL INFORMATION?
+            </a>' above), in and other countries.
+        </span>
+        <div><br></div>
+        <span>
+            If you are a resident in the European Economic Area (EEA) or United Kingdom (UK), then
+            these countries may not necessarily have data protection laws or other similar laws as
+            comprehensive as those in your country. However, we will take all necessary measures to
+            protect your personal information in accordance with this privacy notice and applicable law.
+        </span>
+        <div><br></div>
+        <span>
+            European Commission's Standard Contractual Clauses:
+        </span>
+        <div><br></div>
+        <span>
+            We have implemented measures to protect your personal information, including by using the European
+            Commission's Standard Contractual Clauses for transfers of personal information between our group
+            companies and between us and our third-party providers. These clauses require all
+            recipients to protect all personal information that they process originating from the
+            EEA or UK in accordance with European data protection laws and regulations. Our Standard
+            Contractual Clauses can be provided upon request. We have implemented similar appropriate
+            safeguards with our third-party service providers and partners and further details can be provided
+            upon request.
+        </span>
+    </div>
+    <div id="inforetain" class="line-height-15 body-text privacy-section-div">
+        <h1 class="privacy-h1" id="control">8. HOW LONG DO WE KEEP YOUR INFORMATION?</h1>
+        <span class="privacy-header-subtitle">
+            <strong><em>In Short: </em></strong>
+            <em>We keep your information for as long as necessary to fulfil the purposes outlined in
+                this privacy notice unless otherwise required by law.</em>
+        </span>
+        <div><br></div>
+        <span>
+            We will only keep your personal information for as long as it is necessary for the purposes set out
+            in this privacy notice, unless a longer retention period is required or permitted by law (such as tax,
+            accounting, or other legal requirements). No purpose in this notice will require us keeping your
+            personal information for longer than the period of time in which users have an account with us.
+        </span>
+        <div><br></div>
+        <span>
+            When we have no ongoing legitimate business need to process your personal information, we will either
+            delete or anonymise such information, or, if this is not possible (for example, because your personal
+            information has been stored in backup archives), then we will securely store your personal information
+            and isolate it from any further processing until deletion is possible.
+        </span>
+    </div>
+    <div id="infosafe" class="line-height-15 body-text privacy-section-div">
+        <h1 class="privacy-h1" id="control">9. HOW DO WE KEEP YOUR INFORMATION SAFE?</h1>
+        <span class="privacy-header-subtitle">
+            <strong><em>In Short: </em></strong>
+            <em>We aim to protect your personal information through a system of organisational and
+                technical security measures.</em>
+        </span>
+        <div><br></div>
+        <span>
+            We have implemented appropriate and reasonable technical and organisational security measures
+            designed to protect the security of any personal information we process. However, despite our safeguards
+            and efforts to secure your information, no electronic transmission over the Internet or information
+            storage technology can be guaranteed to be 100% secure, so we cannot promise or guarantee
+            that hackers, cybercriminals, or other unauthorised third parties will not be able to defeat our
+            security and improperly collect, access, steal, or modify your information. Although we will do
+            our best to protect your personal information, transmission of personal information to and from our
+            Services is at your own risk. You should only access the Services within
+            a secure environment.
+        </span>
+    </div>
+    <div id="privacyrights" class="line-height-15 body-text privacy-section-div">
+        <h1 class="privacy-h1">10. WHAT ARE YOUR PRIVACY RIGHTS?</h1>
+        <span class="privacy-header-subtitle">
+            <strong><em>In Short: </em></strong>
+            <em>In some regions, such as the European Economic Area (EEA), United Kingdom (UK), and Canada, you have
+                rights that allow you greater access to and control
+                over your personal information. You may review, change, or terminate your account at any time.
+            </em>
+        </span>
+        <div><br></div>
+        <span>
+            In some regions (like the EEA, UK, and Canada), you have certain rights under applicable data
+            protection laws. These may include the right (i) to request
+            access and obtain a copy of your personal information, (ii) to request rectification or erasure; (iii)
+            to restrict the processing of your personal information; and (iv)
+            if applicable, to data portability. In certain circumstances, you may also have the right to object to
+            the processing of your personal information. You can make such a
+            request by contacting us by using the contact details provided in the section '<a data-custom-class="link"
+                href="/privacy#contact">HOW CAN YOU CONTACT US ABOUT THIS NOTICE?</a>'
+            below.
+        </span>
+        <div><br></div>
+        <span>
+            We will consider and act upon any request in accordance with applicable data protection laws.
+        </span>
+        <div><br></div>
+        <span>
+            If you are located in the EEA or UK and you believe we are unlawfully processing your personal
+            information, you also have the right to complain to your
+            local data protection supervisory authority. You can find their contact details here:
+            <span style="color: rgb(48, 48, 241);">
+                <a class="link" href="https://ec.europa.eu/justice/data-protection/bodies/authorities/index_en.htm"
+                    rel="noopener noreferrer" target="_blank">
+                    https://ec.europa.eu/justice/data-protection/bodies/authorities/index_en.htm
+                </a>
+            </span>
+        </span>
+        <div><br></div>
+        <span>
+            If you are located in Switzerland, the contact details for the data protection authorities are available
+            here:
+            <span style="color: rgb(48, 48, 241);">
+                <a data-custom-class="link" href="https://www.edoeb.admin.ch/edoeb/en/home.html"
+                    rel="noopener noreferrer" target="_blank">https://www.edoeb.admin.ch/edoeb/en/home.html
+                </a>
+            </span>
+        </span>
+        <div><br></div>
+        <div id="withdrawconsent" class="line-height-15 body-text">
+            <span>
+                <strong><u>Withdrawing your consent:</u></strong>
+                If we are relying on your consent to process your personal information, which may be express and/or
+                implied consent depending on the applicable law,
+                you have the right to withdraw your consent at any time. You can withdraw your consent at any time by
+                contacting us by using the contact details provided in
+                the section '<a data-custom-class="link" href="/privacy#contact">HOW CAN YOU CONTACT US ABOUT THIS
+                    NOTICE?</a>'
+                below or updating your preferences.
+            </span>
+            <div><br></div>
+            <span>
+                However, please note that this will not affect the lawfulness of the processing before its withdrawal
+                nor, when applicable law allows, will it affect the processing
+                of your personal information conducted in reliance on lawful processing grounds other than consent.
+            </span>
+        </div>
+        <div><br></div>
+        <div id="accountinfo" class="line-height-15 body-text">
+            <h2 class="privacy-h2">Account Information</h2>
+            <div><br></div>
+            <span>
+                If you would at any time like to review or change the information in your account or terminate your
+                account, you can:
+            </span>
+            <ul>
+                <li class="margin-16">
+                    <span>
+                        Log in to your account settings and update your user account.
+                    </span>
+                </li>
+                <li class="margin-16">
+                    <span>
+                        Contact us using the contact information provided.
+                    </span>
+                </li>
+            </ul>
+            <span>
+                Upon your request to terminate your account, we will deactivate or delete your account and information
+                from our active databases. However, we may
+                retain some information in our files to prevent fraud, troubleshoot problems, assist with any
+                investigations, enforce our legal terms and/or comply with
+                applicable legal requirements.
+            </span>
+            <div><br></div>
+            <span>
+                <strong><u>Cookies and similar technologies:</u></strong>
+                Most Web browsers are set to accept cookies by default. If you prefer, you can usually choose to set
+                your browser to
+                remove cookies and to reject cookies. If you choose to remove cookies or reject cookies, this could
+                affect certain features or
+                services of our Services. To opt out of interest-based advertising by advertisers on our Services visit
+                <span style="color: rgb(48, 48, 241);">
+                    <a data-custom-class="link" href="http://www.aboutads.info/choices/" rel="noopener noreferrer"
+                        target="_blank">http://www.aboutads.info/choices/</a>
+                </span>.
+            </span>
+            <div><br></div>
+            <span>
+                If you have questions or comments about your privacy rights, you may email us at support@katsurin.com.
+            </span>
+        </div>
+    </div>
+    <div id="DNT" class="line-height-15 body-text privacy-section-div">
+        <h1 class="privacy-h1" id="control">11. CONTROLS FOR DO-NOT-TRACK FEATURES</h1>
+        <span>
+            Most web browsers and some mobile operating systems and mobile applications include a Do-Not-Track
+            ('DNT') feature or setting you can
+            activate to signal your privacy preference not to have data about your online browsing activities
+            monitored and collected.
+            At this stage no uniform technology standard for recognising and implementing DNT signals has been
+            finalised. As such, we do not currently respond to DNT browser
+            signals or any other mechanism that automatically communicates your choice not to be tracked online. If
+            a standard for online tracking is adopted that we must follow in
+            the future, we will inform you about that practice in a revised version of this privacy notice.
+        </span>
+    </div>
+    <div id="caresidents" class="line-height-15 body-text privacy-section-div">
+        <h1 class="privacy-h1" id="control">12. DO CALIFORNIA RESIDENTS HAVE SPECIFIC PRIVACY RIGHTS?</h1>
+        <span class="privacy-header-subtitle">
+            <strong><em>In Short: </em></strong>
+            <em>Yes, if you are a resident of California, you are granted specific rights regarding access to your
+                personal information.</em>
+        </span>
+        <div><br></div>
+        <span>
+            California Civil Code Section 1798.83, also known as the 'Shine The Light' law, permits our users who
+            are California residents to request and
+            obtain from us, once a year and free of charge, information about categories of personal information (if
+            any) we disclosed to third
+            parties for direct marketing purposes and the names and addresses of all third parties with which we
+            shared personal information in the immediately preceding
+            calendar year. If you are a California resident and would like to make such a request, please submit
+            your request in writing to us using the contact information
+            provided below.
+        </span>
+        <div><br></div>
+        <span>
+            If you are under 18 years of age, reside in California, and have a registered account with
+            Services, you have the right to
+            request removal of unwanted data that you publicly post on the Services. To request removal
+            of such data, please contact us using the
+            contact information provided below and include the email address associated with your
+            account and a statement that you reside in California. We will
+            make sure the data is not publicly displayed on the Services, but please be aware that the
+            data may not be completely or comprehensively removed from all our
+            systems (e.g. backups, etc.).
+        </span>
+        <div><br></div>
+        <div id="ccpaprivacynotice" class="line-height-15 body-text">
+            <h2 class="privacy-h2">CCPA Privacy Notice</h2>
+            <br>
+            <span>
+                The California Code of Regulations defines a 'resident' as:
+            </span>
+            <div><br></div>
+            <div class="margin-left-20">
+                <span>
+                    (1) every individual who is in the State of California for other than a temporary or
+                    transitory purpose and
+                </span>
+            </div>
+            <div class="margin-left-20">
+                <span>
+                    (2) every individual who is domiciled in the State of California who is outside the State of
+                    California for a temporary or transitory purpose
+                </span>
+            </div>
+            <div><br></div>
+            <span>
+                All other individuals are defined as 'non-residents'.
+            </span>
+            <div><br></div>
+            <span>
+                If this definition of 'resident' applies to you, we must adhere to certain rights and
+                obligations regarding your personal information.
+            </span>
+        </div>
+        <div><br></div>
+        <div class="line-height-15 body-text">
+            <span>
+                <strong>What categories of personal information do we collect?</strong>
+            </span>
+            <div><br></div>
+            <span>
+                We have collected the following categories of personal information in the past twelve
+                (12) months:
+            </span>
+            <div><br></div>
+            <table class="width-100 body-text">
+                <tbody>
+                    <tr>
+                        <td class="table-borders-left">
+                            <span><strong>Category</strong></span>
+                        </td>
+                        <td class="table-border-center">
+                            <span><strong>Examples</strong></span>
+                        </td>
+                        <td class="table-border-right">
+                            <span><strong>Collected</strong></span>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="table-borders-left">
+                            <span>A. Identifiers</span>
+                        </td>
+                        <td class="table-border-center">
+                            <span>
+                                Contact details, such as real name, alias, postal address, telephone or
+                                mobile contact number, unique personal identifier, online identifier,
+                                Internet Protocol address, email address, and account name
+                            </span>
+                        </td>
+                        <td class="table-border-right vertical-align-middle">
+                            <div><br></div>
+                            <span>YES</span>
+                            <div><br></div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="table-borders-left">
+                            <span>
+                                B. Personal information categories listed in the California Customer Records statute
+                            </span>
+                        </td>
+                        <td class="table-border-center">
+                            <span>
+                                Name, contact information, education, employment, employment history, and financial
+                                information
+                            </span>
+                        </td>
+                        <td class="table-border-right">
+                            <div><br></div>
+                            <span>NO</span>
+                            <div><br></div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="table-borders-left">
+                            <span>
+                                C. Protected classification characteristics under California or federal law
+                            </span>
+                        </td>
+                        <td class="table-border-center">
+                            <span>Gender and date of birth</span>
+                        </td>
+                        <td class="table-border-right">
+                            <div><br></div>
+                            <span>YES</span>
+                            <div><br></div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="table-borders-left">
+                            <span>D. Commercial information</span>
+                        </td>
+                        <td class="table-border-center">
+                            <span>Transaction information, purchase history, financial details, and payment
+                                information</span>
+                        </td>
+                        <td class="table-border-right">
+                            <div><br></div>
+                            <span>YES</span>
+                            <div><br></div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="table-borders-left">
+                            <span>E. Biometric information</span>
+                        </td>
+                        <td class="table-border-center">
+                            <span>Fingerprints and voiceprints</span>
+                        </td>
+                        <td class="table-border-right">
+                            <div><br></div>
+                            <span>NO</span>
+                            <div><br></div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="table-borders-left">
+                            <span>F. Internet or other similar network activity</span>
+                        </td>
+                        <td class="table-border-center">
+                            <span>
+                                Browsing history, search history, online behaviour, interest data, and interactions
+                                with our and other websites, applications, systems, and advertisements
+                            </span>
+                        </td>
+                        <td class="table-border-right">
+                            <div><br></div>
+                            <span>YES</span>
+                            <div><br></div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="table-borders-left">
+                            <span>G. Geolocation data</span>
+                        </td>
+                        <td class="table-border-center">
+                            <span>Device location</span>
+                        </td>
+                        <td class="table-border-right">
+                            <div><br></div>
+                            <span>NO</span>
+                            <div><br></div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="table-borders-left">
+                            <span>H. Audio, electronic, visual, thermal, olfactory, or similar information</span>
+                        </td>
+                        <td class="table-border-center">
+                            <span>
+                                Images and audio, video or call recordings created in connection with
+                                our business activities
+                            </span>
+                        </td>
+                        <td class="table-border-right">
+                            <div><br></div>
+                            <span>NO</span>
+                            <div><br></div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="table-borders-left">
+                            <span>I. Professional or employment-related information</span>
+                        </td>
+                        <td class="table-border-center">
+                            <span>
+                                Business contact details in order to provide you our Services at a
+                                business level or job title, work history, and professional
+                                qualifications if you apply for a job with us
+                            </span>
+                        </td>
+                        <td class="table-border-right">
+                            <div><br></div>
+                            <span>NO</span>
+                            <div><br></div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="table-borders-left">
+                            <span>J. Education Information</span>
+                        </td>
+                        <td class="table-border-center">
+                            <span>Student records and directory information</span>
+                        </td>
+                        <td class="table-border-right">
+                            <div><br></div>
+                            <span>NO</span>
+                            <div><br></div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="table-borders-left">
+                            <span>K. Inferences drawn from other personal information</span>
+                        </td>
+                        <td class="table-border-center">
+                            <span>
+                                Inferences drawn from any of the collected personal information listed above to
+                                create a profile or summary about, for example, an individual’s preferences
+                                and characteristics
+                            </span>
+                        </td>
+                        <td class="table-border-right">
+                            <div><br></div>
+                            <span>NO</span>
+                            <div><br></div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="table-border-bottom table-borders-left">
+                            <span>L. Sensitive Personal Information</span>
+                        </td>
+                        <td class="table-border-bottom table-border-center">
+                            <span></span>
+                        </td>
+                        <td class="table-border-bottom table-border-right">
+                            <div><br></div>
+                            <span>NO</span>
+                            <div><br></div>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <div><br></div>
+            <span>
+                We will use and retain the collected personal information as needed to provide the Services or for:
+            </span>
+            <ul>
+                <li class="margin-16">
+                    <span>
+                        Category A - As long as the user has an account with us
+                    </span>
+                </li>
+                <li class="margin-16">
+                    <span>
+                        Category C - As long as the user has an account with us
+                    </span>
+                </li>
+                <li class="margin-16">
+                    <span>
+                        Category D - As long as the user has an account with us
+                    </span>
+                </li>
+                <li class="margin-16">
+                    <span>
+                        Category F - As long as the user has an account with us
+                    </span>
+                </li>
+            </ul>
+            <span>
+                We may also collect other personal information outside of these categories through instances where
+                you interact with us in person, online, or by phone or mail in the context of:
+            </span>
+            <ul>
+                <li class="margin-16">
+                    <span>
+                        Receiving help through our customer support channels;
+                    </span>
+                </li>
+                <li class="margin-16">
+                    <span>
+                        Participation in customer surveys or contests; and
+                    </span>
+                </li>
+                <li class="margin-16">
+                    <span>
+                        Facilitation in the delivery of our Services and to respond to your inquiries.
+                    </span>
+                </li>
+            </ul>
+        </div>
+        <div class="line-height-15 body-text">
+            <span>
+                <strong>How do we use and share your personal information?</strong>
+            </span>
+            <div><br></div>
+            <span>
+                More information about our data collection and sharing practices can be found in this privacy
+                notice.
+            </span>
+            <div><br></div>
+            <span>
+                You may contact us by email at support@katsurin.com, or by referring to the contact details at the
+                bottom of this document.
+            </span>
+            <div><br></div>
+            <span>
+                If you are using an authorised agent to exercise your right to opt out we may deny a request if the
+                authorised agent does not submit proof that they have been validly authorised to act on your behalf.
+            </span>
+        </div>
+        <div><br></div>
+        <div class="line-height-15 body-text">
+            <span>
+                <strong>Will your information be shared with anyone else?</strong>
+            </span>
+            <div><br></div>
+            <span>
+                We may disclose your personal information with our service providers pursuant to a written contract
+                between us and each service provider. Each service provider is a for-profit entity that processes
+                the information on our behalf, following the same strict privacy protection obligations mandated by
+                the CCPA.
+            </span>
+            <div><br></div>
+            <span>
+                We may use your personal information for our own business purposes, such as for undertaking internal
+                research for technological development and demonstration. This is not considered to be 'selling'
+                of your personal information.
+            </span>
+            <div><br></div>
+            <span>
+                Katsurin Studios has not disclosed, sold, or shared any personal information to third parties for
+                a business or commercial purpose in the preceding twelve (12) months. Katsurin Studios will not sell
+                or share personal information in the future belonging to website visitors, users, and other consumers.
+            </span>
+        </div>
+        <div><br></div>
+        <div id="calirights" class="line-height-15 body-text">
+            <span>
+                <strong>Your rights with respect to your personal data</strong>
+            </span>
+            <div><br></div>
+            <div>
+                <span>
+                    <u>Right to request deletion of the data — Request to delete</u>
+                </span>
+                <div><br></div>
+                <span>
+                    You can ask for the deletion of your personal information. If you ask us to delete your personal
+                    information, we will respect your request and delete your personal information, subject to certain
+                    exceptions provided by law, such as (but not limited to) the exercise by another
+                    consumer of his or her right to free speech, our compliance requirements resulting from a legal
+                    obligation, or any processing that may be required to protect against illegal activities.
+                </span>
+            </div>
+            <div><br></div>
+            <div class="line-height-15 body-text">
+                <span>
+                    <u>Right to be informed — Request to know</u>
+                </span>
+                <div><br></div>
+                <span>
+                    Depending on the circumstances, you have a right to know:
+                </span>
+                <ul>
+                    <li class="margin-16">
+                        <span>
+                            whether we collect and use your personal information;
+                        </span>
+                    </li>
+                    <li class="margin-16">
+                        <span>
+                            the categories of personal information that we collect;
+                        </span>
+                    </li>
+                    <li class="margin-16">
+                        <span>
+                            the purposes for which the collected personal information is used;
+                        </span>
+                    </li>
+                    <li class="margin-16">
+                        <span>
+                            whether we sell or share personal information to third parties;
+                        </span>
+                    </li>
+                    <li class="margin-16">
+                        <span>
+                            the categories of personal information that we sold, shared, or disclosed for a business
+                            purpose;
+                        </span>
+                    </li>
+                    <li class="margin-16">
+                        <span>
+                            the categories of third parties to whom the personal
+                            information was sold, shared, or disclosed for a business purpose;
+                        </span>
+                    </li>
+                    <li class="margin-16">
+                        <span>
+                            the business or commercial purpose for collecting, selling, or sharing personal information;
+                            and
+                        </span>
+                    </li>
+                    <li class="margin-16">
+                        <span>
+                            the specific pieces of personal information we collected about you.
+                        </span>
+                    </li>
+                </ul>
+                <span>
+                    In accordance with applicable law, we are not obligated to provide or delete consumer information
+                    that is de-identified in response to a consumer request or to re-identify individual data to
+                    verify a consumer request.
+                </span>
+                <div><br></div>
+                <div>
+                    <span>
+                        <u>Right to Non-Discrimination for the Exercise of a Consumer’s Privacy Rights</u>
+                    </span>
+                    <div><br></div>
+                    <span>
+                        We will not discriminate against you if you exercise your privacy rights.
+                    </span>
+                    <div><br></div>
+                </div>
+            </div>
+            <div>
+                <span>
+                    <u>Right to Limit Use and Disclosure of Sensitive Personal Information</u>
+                </span>
+                <div><br></div>
+                <span>We do not process consumer's sensitive personal information.</span>
+                <div><br></div>
+            </div>
+            <div>
+                <span>
+                    <u>Verification process</u>
+                </span>
+                <div><br></div>
+                <span>
+                    Upon receiving your request, we will need to verify your identity to determine you are the same
+                    person
+                    about whom we have the information in our system. These verification efforts require us to ask you
+                    to
+                    provide information so that we can match it with information you have previously provided us. For
+                    instance, depending on the type of request you submit, we may ask you to provide
+                    certain information so that we can match the information you provide with the information we already
+                    have on file, or we may contact you through a communication method (e.g. phone or email) that you
+                    have
+                    previously provided to us. We may also use other verification methods as the circumstances dictate.
+                </span>
+                <div><br></div>
+                <span>
+                    We will only use personal information provided in your request to verify your identity or authority
+                    to make the request. To the extent possible, we will avoid requesting additional information from
+                    you
+                    for the purposes of verification. However, if we cannot verify your identity from the information
+                    already maintained by us, we may request that you provide additional information for the
+                    purposes of verifying your identity and for security or fraud-prevention purposes. We will delete
+                    such
+                    additionally provided information as soon as we finish verifying you.
+                </span>
+                <div><br></div>
+            </div>
+            <div>
+                <span>
+                    <u>Other privacy rights</u>
+                </span>
+                <ul>
+                    <li class="margin-16">
+                        <span>
+                            You may object to the processing of your personal information.
+                        </span>
+                    </li>
+                    <li class="margin-16">
+                        <span>
+                            You may request correction of your personal data if it is incorrect or no longer relevant,
+                            or ask to restrict the processing of the information.
+                        </span>
+                    </li>
+                    <li class="margin-16">
+                        <span>
+                            You can designate an authorised agent to make a request under the CCPA on your behalf.
+                            We may deny a request from an authorised agent that does not submit proof that they have
+                            been validly authorised to act on your behalf in accordance with the CCPA.
+                        </span>
+                    </li>
+                    <li class="margin-16">
+                        <span>
+                            You may request to opt out from future selling or sharing of your personal information to
+                            third parties. Upon receiving an opt-out request,
+                            we will act upon the request as soon as feasibly possible, but no later than fifteen (15)
+                            days from the date of the request submission.
+                        </span>
+                    </li>
+                </ul>
+            </div>
+            <span>
+                To exercise these rights, you can contact us by email at support@katsurin.com,
+                or by referring to the contact details at the bottom of this document. If you
+                have a complaint about how we handle your data, we would like to hear from you.
+            </span>
+        </div>
+    </div>
+    <div id="virginia" class="line-height-15 body-text privacy-section-div">
+        <h1 class="privacy-h1">13. DO VIRGINIA RESIDENTS HAVE SPECIFIC PRIVACY RIGHTS?</h1>
+        <span class="privacy-header-subtitle">
+            <em><strong>In Short: </strong>
+                Yes, if you are a resident of Virginia, you may be granted specific rights regarding access to and
+                use of your personal information.
+            </em>
+        </span>
+        <div><br></div>
+        <div class="privacy-section-subcontainer">
+            <h2 class="privacy-h2">Virginia CDPA Privacy Notice</h2>
+            <div><br></div>
+            <span>Under the Virginia Consumer Data Protection Act (CDPA):</span>
+            <div><br></div>
+            <span>
+                'Consumer' means a natural person who is a resident of the Commonwealth acting only in an individual
+                or household context. It does not include a natural person acting in
+                a commercial or employment context.
+            </span>
+            <div><br></div>
+            <span>
+                'Personal data' means any information that is linked or reasonably linkable to an identified or
+                identifiable natural person. 'Personal data' does not include de-identified data or publicly
+                available information.
+            </span>
+            <div><br></div>
+            <span>
+                'Sale of personal data' means the exchange of personal data for monetary consideration.
+            </span>
+            <div><br></div>
+            <span>
+                If this definition 'consumer' applies to you, we must adhere to certain rights and obligations
+                regarding your personal data.
+            </span>
+            <div><br></div>
+            <span>
+                The information we collect, use, and disclose about you will vary depending on how you interact with
+                Katsurin Studios and our Services. To find out more, please visit the following links:
+            </span>
+            <ul>
+                <li class="margin-16">
+                    <span>
+                        <a class="link" href="/privacy#infocollect">Personal data we
+                            collect</a>
+                    </span>
+                </li>
+                <li class="margin-16">
+                    <span>
+                        <a class="link" href="/privacy#infouse">How we use your personal
+                            data</a>
+                    </span>
+                </li>
+                <li class="margin-16">
+                    <span>
+                        <a class="link" href="/privacy#whoshare">When and with whom we
+                            share your personal data</a>
+                    </span>
+                </li>
+            </ul>
+        </div>
+        <div class="line-height-15 body-text">
+            <span>
+                <u>Your rights with respect to your personal data</u>
+            </span>
+            <ul>
+                <li class="margin-16">
+                    <span>
+                        Right to be informed whether or not we are processing your personal
+                        data
+                    </span>
+                </li>
+                <li class="margin-16">
+                    <span>
+                        Right to access your personal data
+                    </span>
+                </li>
+                <li class="margin-16">
+                    <span>
+                        Right to correct inaccuracies in your personal data
+                    </span>
+                </li>
+                <li class="margin-16">
+                    <span>
+                        Right to request deletion of your personal data
+                    </span>
+                </li>
+                <li class="margin-16">
+                    <span>
+                        Right to obtain a copy of the personal data you previously shared with us
+                    </span>
+                </li>
+                <li class="margin-16">
+                    <span>
+                        Right to opt out of the processing of your personal data if it is used for targeted advertising,
+                        the sale of personal data, or profiling in furtherance of decisions that produce legal or
+                        similarly significant effects ('profiling')
+                    </span>
+                </li>
+            </ul>
+        </div>
+        <span>
+            Katsurin Studios has not sold any personal data to third parties for business or commercial purposes.
+            Katsurin Studios will not sell personal data in the future belonging to website visitors, users, and
+            other consumers.
+        </span>
+        <div><br></div>
+        <div class="line-height-15 body-text">
+            <span>
+                <u>Exercise your rights provided under the Virginia CDPA</u>
+            </span>
+            <div><br></div>
+            <span>
+                More information about our data collection and sharing practices can be found in this privacy notice.
+            </span>
+            <div><br></div>
+            <span>
+                You may contact us by email at support@katsurin.com, by visiting our
+                <a href="https://app.termly.io/notify/4e2f4038-d2fa-4cab-90ea-ba2981b3cf9d" rel="noopener noreferrer"
+                    target="_blank" class="link">data subject request form</a>, or by referring to the
+                contact details at the bottom of this document.
+            </span>
+            <div><br></div>
+            <span>
+                If you are using an authorised agent to exercise your rights, we may deny a request if the authorised
+                agent does not submit proof that they have been validly authorised to act on your behalf.
+            </span>
+            <div><br></div>
+        </div>
+        <div class="line-height-15 body-text">
+            <span>
+                <u>Verification process</u>
+            </span>
+            <div><br></div>
+            <span>
+                We may request that you provide additional information reasonably necessary to verify you and your
+                consumer's request. If you submit the request through an authorised agent, we may need to collect
+                additional information to verify your identity before processing your request.
+            </span>
+            <div><br></div>
+            <span>
+                Upon receiving your request, we will respond without undue delay, but in all cases, within forty-five
+                (45) days of receipt. The response period may be extended once by forty-five (45) additional days
+                when reasonably necessary. We will inform you of any such extension within the initial 45-day
+                response period, together with the reason for the extension.
+            </span>
+            <div><br></div>
+        </div>
+        <div class="line-height-15 body-text">
+            <span>
+                <u>Right to appeal</u>
+            </span>
+            <div><br></div>
+            <span>
+                If we decline to take action regarding your request, we will inform you of our decision and reasoning
+                behind it. If you wish to appeal our decision, please email us at support@katsurin.com. Within
+                sixty (60) days of receipt of an appeal, we will inform you in writing of any action taken or not
+                taken in response to the appeal, including a written explanation of the reasons for the
+                decisions. If your appeal if denied, you may contact the Attorney General to
+                <a href="https://www.oag.state.va.us/consumer-protection/index.php/file-a-complaint"
+                    rel="noopener noreferrer" target="_blank" class="link">submit a complaint</a>.</span>
+        </div>
+    </div>
+    <div id="policyupdates" class="line-height-15 body-text privacy-section-div">
+        <h1 class="privacy-h1" id="control">14. DO WE MAKE UPDATES TO THIS NOTICE?</h1>
+        <span class="privacy-header-subtitle">
+            <em><strong>In Short: </strong>
+                Yes, we will update this notice as necessary to stay compliant with relevant laws.
+            </em>
+        </span>
+        <div><br></div>
+        <span>
+            We may update this privacy notice from time to time. The updated version will be indicated by an updated
+            'Revised' date and the updated version will be effective as soon as it is accessible. If we make
+            material changes to this privacy notice,
+            we may notify you either by prominently posting a notice of such changes or by directly sending you a
+            notification. We encourage you to review this privacy notice
+            frequently to be informed of how we are protecting your information.
+        </span>
+    </div>
+    <div id="contact" class="line-height-15 body-text privacy-section-div">
+        <h1 class="privacy-h1" id="control">15. HOW CAN YOU CONTACT US ABOUT THIS NOTICE?</h1>
+        <span>
+            If you have questions or comments about this notice, you
+            may email us at support@katsurin.com or by post to:
+        </span>
+        <div><br></div>
+        <span>Katsurin Studios</span>
+        <br>
+        <span>1012 Sandel Lane</span>
+        <br>
+        <span>Raleigh, NC 27603</span>
+        <br>
+        <span>United States</span>
+    </div>
+    <div id="request" class="line-height-15 body-text">
+        <h1 class="privacy-h1" id="control">16. HOW CAN YOU REVIEW, UPDATE, OR DELETE THE DATA WE COLLECT FROM YOU?
+        </h1>
+        <span>
+            You have the right to request access to the personal
+            information we collect from you, change that
+            information, or delete it. To request to review, update,
+            or delete your personal information, please fill out and
+            submit a
+        </span>
+        <span style="color: rgb(48, 48, 241);">
+            <a class="link" href="https://app.termly.io/notify/4e2f4038-d2fa-4cab-90ea-ba2981b3cf9d"
+                rel="noopener noreferrer" target="_blank">data
+                subject access request</a>
+        </span>
+        <span>.</span>
+    </div>
+    <div class="termly-footer">
+        This privacy policy was created using Termly's
+        <a style="color: rgb(48, 48, 241) !important;"
+            href="https://termly.io/products/privacy-policy-generator/">Privacy
+            Policy Generator</a>.
+    </div>
+</div>

--- a/src/app/privacy-page/privacy-page.component.spec.ts
+++ b/src/app/privacy-page/privacy-page.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+
+import { PrivacyPageComponent } from "./privacy-page.component";
+
+describe("PrivacyPageComponent", () => {
+	let component: PrivacyPageComponent;
+	let fixture: ComponentFixture<PrivacyPageComponent>;
+
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+			declarations: [PrivacyPageComponent]
+		}).compileComponents();
+
+		fixture = TestBed.createComponent(PrivacyPageComponent);
+		component = fixture.componentInstance;
+		fixture.detectChanges();
+	});
+
+	it("should create", () => {
+		expect(component).toBeTruthy();
+	});
+});

--- a/src/app/privacy-page/privacy-page.component.ts
+++ b/src/app/privacy-page/privacy-page.component.ts
@@ -1,0 +1,9 @@
+import { Component } from "@angular/core";
+
+@Component({
+	standalone: true,
+	selector: "privacy-page",
+	templateUrl: "./privacy-page.component.html",
+	styleUrls: ["./privacy-page.component.css"]
+})
+export class PrivacyPageComponent {}


### PR DESCRIPTION
<!-- 
    Thank you for contributing! 
    If you have not already, please review the contribution guidelines before submitting:
    https://github.com/Butterstroke/Myneworm/tree/master/.github/CONTRIBUTING.md
-->

## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Adds a privacy policy which covers Myneworm's capabilities currently and current planned updates.

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

Created a new privacy page component to hold the current policy. Then, updated the footer to contain the privacy link for people to access.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->

Internal#785

## Other Information:
<!-- For anything else worth mentioning that doesn't fit in your description, put here. -->
Existing users and visitors should be notified that a policy is in place once released. Existing users can be emailed a link while visitors should be notified via the Discord announcements.