### PR TITLE
fix(privacy-page): metadata

### DIFF
--- a/src/app/privacy-page/privacy-page.component.ts
+++ b/src/app/privacy-page/privacy-page.component.ts
@@ -1,4 +1,5 @@
 import { Component } from "@angular/core";
+import { MetadataService } from "../services/metadata.service";
 
 @Component({
 	standalone: true,
@@ -6,4 +7,8 @@ import { Component } from "@angular/core";
 	templateUrl: "./privacy-page.component.html",
 	styleUrls: ["./privacy-page.component.css"]
 })
-export class PrivacyPageComponent {}
+export class PrivacyPageComponent {
+	constructor(private metaService: MetadataService) {
+		this.metaService.updateMetaTags("Privacy Policy", "/privacy");
+	}
+}


### PR DESCRIPTION
## What Does This Do?
It adds the meta tag data to the privacy-page.

## How is it Done?
It was done by importing the Meta service and then injecting it to the component using the updateMetaTags function.

## Related Tickets and Issues
Task #787 from Myneworm Kanban board