### PR TITLE
[Fix/766] Added New Classes to Schedule Tags and Updated CSS

### DIFF
--- a/src/app/home-page/home-page.component.ts
+++ b/src/app/home-page/home-page.component.ts
@@ -73,9 +73,9 @@ export class HomePageComponent implements OnInit {
 						const typeTag = document.createElement("div");
 						const bookTitle = document.createElement("div");
 
-						formatTag.className = `${formatCSS(arg.event.extendedProps.format)} schedule-tag`;
+						formatTag.className = `${formatCSS(arg.event.extendedProps.format)} format-tag schedule-tag`;
 						imprintTag.className = `${formatCSS(arg.event.extendedProps.imprint)} schedule-tag`;
-						typeTag.className = `${formatCSS(arg.event.extendedProps.bookType)} schedule-tag`;
+						typeTag.className = `${formatCSS(arg.event.extendedProps.bookType)} type-tag schedule-tag`;
 						bookTitle.className = "book-title";
 
 						formatTag.innerHTML = formatText(arg.event.extendedProps.format);

--- a/src/app/imprint-page/imprint-page.component.ts
+++ b/src/app/imprint-page/imprint-page.component.ts
@@ -67,10 +67,10 @@ export class ImprintPageComponent implements OnInit {
 
 						formatTag.className = `${UtilityService.formatCSSClass(
 							arg.event.extendedProps.format
-						)} schedule-tag`;
+						)} format-tag schedule-tag`;
 						typeTag.className = `${UtilityService.formatCSSClass(
 							arg.event.extendedProps.bookType
-						)} schedule-tag`;
+						)} type-tag schedule-tag`;
 						bookTitle.className = "book-title";
 
 						formatTag.innerHTML = UtilityService.formatReadable(arg.event.extendedProps.format);

--- a/src/app/shared/calendar-styles.css
+++ b/src/app/shared/calendar-styles.css
@@ -57,10 +57,14 @@ tr.fc-list-event {
     float: left;
     margin-right: 4px;
     background-color: #2DC9F0;
-    width: 100px;
+    width: 125px;
     height: 20px;
     align-items: center;
     justify-content: center;
+}
+
+.format-tag, .type-tag {
+    width: 100px;
 }
 
 .schedule-tag a, .schedule-tag a:hover {


### PR DESCRIPTION
<!-- 
    Thank you for contributing! 
    If you have not already, please review the contribution guidelines before submitting:
    https://github.com/Butterstroke/Myneworm/tree/master/.github/CONTRIBUTING.md
-->

## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Fixes a styling issue where the imprint would not fit in the schedule tag if it was longer than a particular amount of characters.

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

Updated the format and type schedule tags on the calendars to use a `.format-tag` and a `.type-tag` respectively to maintain the CSS width. Then updated the original `.schedule-tag` width value to fit the larger imprint names.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->

Internal#766