### PR TITLE
[Feature/808] Create a User Settings Page

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -15,6 +15,7 @@ import { PrivacyPageComponent } from "./privacy-page/privacy-page.component";
 import { DatabaseGuidelinesComponent } from "./database-guidelines/database-guidelines.component";
 import { LoginPageComponent } from "./login-page/login-page.component";
 import { AuthenticationGuard } from "./services/authentication/authentication.guard";
+import { UserSettingsPageComponent } from "./user-settings-page/user-settings-page.component";
 
 const routes: Routes = [
 	{ path: "", component: HomePageComponent },
@@ -32,6 +33,8 @@ const routes: Routes = [
 	{ path: "guidelines", component: DatabaseGuidelinesComponent },
 	{ path: "login", component: LoginPageComponent },
 	{ path: "login/authorized", component: LoginPageComponent, canActivate: [AuthenticationGuard] },
+	{ path: "settings", pathMatch: "full", component: UserSettingsPageComponent, canActivate: [AuthenticationGuard] },
+	{ path: "settings/:page", component: UserSettingsPageComponent, canActivate: [AuthenticationGuard] },
 	{ path: "**", pathMatch: "full", component: MissingPageComponent }
 ];
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -25,6 +25,7 @@ import { DatabaseGuidelinesComponent } from "./database-guidelines/database-guid
 import { LoginPageComponent } from "./login-page/login-page.component";
 import { UserNavMenuComponent } from "./user-nav-menu/user-nav-menu.component";
 import { LocalCookiesService } from "./services/authentication/local-cookies.service";
+import { UserSettingsPageComponent } from "./user-settings-page/user-settings-page.component";
 @NgModule({
 	declarations: [
 		AppComponent,
@@ -34,7 +35,8 @@ import { LocalCookiesService } from "./services/authentication/local-cookies.ser
 		DataCorrectionFormComponent,
 		ContactPageComponent,
 		LoginPageComponent,
-		UserNavMenuComponent
+		UserNavMenuComponent,
+		UserSettingsPageComponent
 	],
 	imports: [
 		BrowserModule,

--- a/src/app/user-nav-menu/user-nav-menu.component.html
+++ b/src/app/user-nav-menu/user-nav-menu.component.html
@@ -3,7 +3,7 @@
     <div class="user-menu">
         <ul>
             <li><a class="user-menu-link" href="/">Profile</a></li>
-            <li><a class="user-menu-link" href="/">Settings</a></li>
+            <li><a class="user-menu-link" href="/settings">Settings</a></li>
             <li><a class="user-menu-link" (click)="logout()">Logout</a></li>
         </ul>
     </div>

--- a/src/app/user-settings-page/user-settings-page.component.css
+++ b/src/app/user-settings-page/user-settings-page.component.css
@@ -10,20 +10,16 @@
     font-size: x-large;
 }
 
-.settings-menu > a {
+.settings-menu > a, .settings-menu > a:visited, .settings-menu > a:hover {
+    width: 100%;
+    text-align: center;
     text-decoration: none;
     margin-top: 12px;
     margin-bottom: 12px;
     color: #1f2232;
 }
 
-.settings-menu > a:visited, .settings-menu > a:hover {
-    color: #1f2232;
-}
-
 .settings-menu > a.current {
-    width: 100%;
-    text-align: center;
     border-radius: 8px;
     padding: 8px 6px;
     background-color: #2dc9f0;
@@ -74,4 +70,17 @@ label {
     margin-bottom: 5px;
     width: 300px;
     height: 25px;
+}
+
+.settings-textarea {
+    resize: none;
+    width: 300px;
+    height: 150px;
+}
+
+.missing-avatar {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 2px dashed black;
 }

--- a/src/app/user-settings-page/user-settings-page.component.css
+++ b/src/app/user-settings-page/user-settings-page.component.css
@@ -1,0 +1,77 @@
+.settings-menu {
+    width: 15%;
+    float: left;
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    flex-wrap: nowrap;
+    margin-left: 5%;
+    margin-right: 5%;
+    font-size: x-large;
+}
+
+.settings-menu > a {
+    text-decoration: none;
+    margin-top: 12px;
+    margin-bottom: 12px;
+    color: #1f2232;
+}
+
+.settings-menu > a:visited, .settings-menu > a:hover {
+    color: #1f2232;
+}
+
+.settings-menu > a.current {
+    width: 100%;
+    text-align: center;
+    border-radius: 8px;
+    padding: 8px 6px;
+    background-color: #2dc9f0;
+    margin-top: 4px;
+    margin-bottom: 4px;
+}
+
+.settings-content {
+    width: 65%;
+    float: left;
+    margin-right: 10%
+}
+
+label {
+    cursor: pointer;
+}
+
+#avatarFile {
+    opacity: 0;
+    position: absolute;
+    z-index: -1;
+}
+
+.settings-button {
+    width: 10%;
+    min-width: 200px;
+    text-align: center;
+    padding-top: 8px;
+    padding-bottom: 8px;
+    border: none;
+    margin-top: 10px;
+}
+
+.avatar-display {
+    width: 250px;
+    height: 250px;
+}
+
+.settings-subdiv {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    flex-wrap: nowrap;
+}
+
+.settings-input {
+    margin-top: 5px;
+    margin-bottom: 5px;
+    width: 300px;
+    height: 25px;
+}

--- a/src/app/user-settings-page/user-settings-page.component.html
+++ b/src/app/user-settings-page/user-settings-page.component.html
@@ -7,16 +7,20 @@
     <div class="settings-content">
         <div *ngIf="currPage === 'PROFILE'">
             <h3>About Me</h3>
-            <textarea></textarea>
+            <textarea name="aboutMe" autocomplete="off" class="settings-textarea"></textarea>
             <br>
             <h3>Avatar</h3>
             <img class="avatar-display" *ngIf="url !== undefined" src={{url}}>
+            <div class="avatar-display missing-avatar" *ngIf="url === undefined">
+                No image uploaded
+            </div>
             <form>
                 <div class="button-div settings-button">
                     <label for="avatarFile" class="button-link button-text">Upload File</label>
                     <input type="file" id="avatarFile" name="avatar" accept="image/jpeg" (change)="onFileChanged($event)">
                 </div>                
             </form>
+            <br>
             <button class="button-div button-link settings-button" type="submit" name="Submit" value="Submit">Save</button>
         </div>
 

--- a/src/app/user-settings-page/user-settings-page.component.html
+++ b/src/app/user-settings-page/user-settings-page.component.html
@@ -10,6 +10,7 @@
             <textarea name="aboutMe" autocomplete="off" class="settings-textarea"></textarea>
             <br>
             <h3>Avatar</h3>
+            <p *ngIf="message !== undefined">{{message}}</p>
             <img class="avatar-display" *ngIf="url !== undefined" src={{url}}>
             <div class="avatar-display missing-avatar" *ngIf="url === undefined">
                 No image uploaded

--- a/src/app/user-settings-page/user-settings-page.component.html
+++ b/src/app/user-settings-page/user-settings-page.component.html
@@ -1,0 +1,45 @@
+<div class="settings-page">
+    <aside class="settings-menu">
+        <h2 style="font-size: xx-large;">Settings</h2>
+        <a routerLink="/settings/profile" [ngClass]="{current: currPage === 'PROFILE'}">Profile</a>
+        <a routerLink="/settings/account" [ngClass]="{current: currPage === 'ACCOUNT'}">Account</a>
+    </aside>
+    <div class="settings-content">
+        <div *ngIf="currPage === 'PROFILE'">
+            <h3>About Me</h3>
+            <textarea></textarea>
+            <br>
+            <h3>Avatar</h3>
+            <img class="avatar-display" *ngIf="url !== undefined" src={{url}}>
+            <form>
+                <div class="button-div settings-button">
+                    <label for="avatarFile" class="button-link button-text">Upload File</label>
+                    <input type="file" id="avatarFile" name="avatar" accept="image/jpeg" (change)="onFileChanged($event)">
+                </div>                
+            </form>
+            <button class="button-div button-link settings-button" type="submit" name="Submit" value="Submit">Save</button>
+        </div>
+
+        <div *ngIf="currPage === 'ACCOUNT'">
+            <h3>Username</h3>
+            <input class="settings-input">
+            <h3>Email</h3>
+            <input type="email" class="settings-input">
+            <h3>Password</h3>
+            <div class="settings-subdiv">
+                <input type="password" placeholder="New Password" class="settings-input">
+                <input type="password" placeholder="Confirm Password" class="settings-input">
+            </div>
+            <br>            
+            <button class="button-div button-link settings-button" type="submit" name="Submit" value="Submit">Save</button>
+            <br><br>
+            <h3>Delete Your Account</h3>
+            <div class="settings-subdiv">
+                <p>By clicking this button, your account will be flagged for deletion. You will have up to 48 hours after
+                    submission to revert this change. Afterwards, your account will be deleted and there is no recovery
+                    beyond the 48 hour grace period.</p>
+                <button class="button-div button-link settings-button">Delete My Account</button>
+            </div>            
+        </div>
+    </div>
+</div>

--- a/src/app/user-settings-page/user-settings-page.component.spec.ts
+++ b/src/app/user-settings-page/user-settings-page.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+
+import { UserSettingsPageComponent } from "./user-settings-page.component";
+
+describe("UserSettingsPageComponent", () => {
+	let component: UserSettingsPageComponent;
+	let fixture: ComponentFixture<UserSettingsPageComponent>;
+
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+			declarations: [UserSettingsPageComponent]
+		}).compileComponents();
+
+		fixture = TestBed.createComponent(UserSettingsPageComponent);
+		component = fixture.componentInstance;
+		fixture.detectChanges();
+	});
+
+	it("should create", () => {
+		expect(component).toBeTruthy();
+	});
+});

--- a/src/app/user-settings-page/user-settings-page.component.ts
+++ b/src/app/user-settings-page/user-settings-page.component.ts
@@ -1,0 +1,54 @@
+import { Component, OnInit } from "@angular/core";
+import { ActivatedRoute } from "@angular/router";
+import { MynewormAPIService } from "../services/myneworm-api.service";
+
+@Component({
+	selector: "user-settings-page",
+	templateUrl: "./user-settings-page.component.html",
+	styleUrls: ["./user-settings-page.component.css"]
+})
+export class UserSettingsPageComponent implements OnInit {
+	currPage: string;
+	avatar: unknown;
+	message: string;
+	imagePath: unknown;
+	url: string | ArrayBuffer | null;
+
+	constructor(private route: ActivatedRoute, private service: MynewormAPIService) {}
+
+	ngOnInit() {
+		this.route.params.subscribe((data) => {
+			if (data.page) {
+				this.currPage = data.page.toUpperCase();
+			} else {
+				this.currPage = "PROFILE";
+			}
+		});
+	}
+
+	updatePage(clickEvent: string) {
+		this.currPage = clickEvent;
+	}
+
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore
+	onFileChanged(event) {
+		const files = event.target.files;
+		if (files.length === 0) {
+			return;
+		}
+
+		const mimeType = files[0].type;
+		if (mimeType.match(/image\/*/) === null) {
+			this.message = "Only images are supported.";
+			return;
+		}
+
+		const reader = new FileReader();
+		this.imagePath = files;
+		reader.readAsDataURL(files[0]);
+		reader.onload = (_event) => {
+			this.url = reader.result;
+		};
+	}
+}

--- a/src/app/user-settings-page/user-settings-page.component.ts
+++ b/src/app/user-settings-page/user-settings-page.component.ts
@@ -11,7 +11,6 @@ export class UserSettingsPageComponent implements OnInit {
 	currPage: string;
 	avatar: unknown;
 	message: string;
-	imagePath: unknown;
 	url: string | ArrayBuffer | null;
 
 	constructor(private route: ActivatedRoute, private service: MynewormAPIService) {}
@@ -38,16 +37,14 @@ export class UserSettingsPageComponent implements OnInit {
 			return;
 		}
 
-		const mimeType = files[0].type;
-		if (mimeType.match(/image\/*/) === null) {
+		if (files[0].type.match(/image\/*/) === null) {
 			this.message = "Only images are supported.";
 			return;
 		}
 
 		const reader = new FileReader();
-		this.imagePath = files;
 		reader.readAsDataURL(files[0]);
-		reader.onload = (_event) => {
+		reader.onload = () => {
 			this.url = reader.result;
 		};
 	}


### PR DESCRIPTION
<!-- 
    Thank you for contributing! 
    If you have not already, please review the contribution guidelines before submitting:
    https://github.com/Butterstroke/Myneworm/tree/master/.github/CONTRIBUTING.md
-->

## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Create a user settings page (found at `/settings`) so users can update and delete their accounts as needed by themselves.

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

Created a component and designed the page layout. Back-end work and API requests will follow in an additional ticket.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->

Internal#808