### PR TITLE
[Fix/818] Fixed Search Bar Scrolling with User

### DIFF
--- a/src/app/search-bar/search-bar.component.css
+++ b/src/app/search-bar/search-bar.component.css
@@ -2,7 +2,7 @@
     width: 300px;
     font-size: large;
     z-index: 99;
-    position: fixed;
+    position: absolute;
 }
 
 .search-bar > form {
@@ -13,9 +13,6 @@
 .search-table {
     z-index: 99;
     position: relative;
-}
-
-div.search-bar > .search-table {
     display: none;
 }
 
@@ -38,14 +35,12 @@ div.search-bar:hover > form > button.no-radius-bottom-right {
     border-bottom-right-radius: 0px;
 }
 
-
 .search-cover-img {
     max-height: 50px;
 }
 
 .search-image-row {
     display: flex;
-    align-items: center;
     justify-content: center;
     padding-top: 4px;
     padding-bottom: 4px;
@@ -75,7 +70,6 @@ div.search-bar:hover > form > button.no-radius-bottom-right {
     border: solid;
     border-radius: 8px 0 0 8px;
     border-color: #fff;
-    border-right: solid;
     border-right-color: #1F2232;
     border-right-width: 1px;
     padding-left: 1em;


### PR DESCRIPTION
<!-- 
    Thank you for contributing! 
    If you have not already, please review the contribution guidelines before submitting:
    https://github.com/Butterstroke/Myneworm/tree/master/.github/CONTRIBUTING.md
-->

## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Fixes the search bar positioning when scrolling down pages. The search bar will now remain within the navigation bar.

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

Updated the CSS styling from `fixed` to `absolute`.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->

Internal#818