### PR TITLE
[Feature/826] Added Lazy Load Functionality to Static Component Pages

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -6,13 +6,9 @@ import { ImprintPageComponent } from "./imprint-page/imprint-page.component";
 import { ImprintIndexComponent } from "./imprint-index/imprint-index.component";
 import { MissingPageComponent } from "./missing-page/missing-page.component";
 import { SeriesPageComponent } from "./series-page/series-page.component";
-import { FaqPageComponent } from "./faq-page/faq-page.component";
-import { AboutPageComponent } from "./about-page/about-page.component";
 import { DataCorrectionFormComponent } from "./data-correction-form/data-correction-form.component";
 import { ContactPageComponent } from "./contact-page/contact-page.component";
 import { SearchPageComponent } from "./search-page/search-page.component";
-import { PrivacyPageComponent } from "./privacy-page/privacy-page.component";
-import { DatabaseGuidelinesComponent } from "./database-guidelines/database-guidelines.component";
 import { LoginPageComponent } from "./login-page/login-page.component";
 import { AuthenticationGuard } from "./services/authentication/authentication.guard";
 import { UserSettingsPageComponent } from "./user-settings-page/user-settings-page.component";
@@ -25,12 +21,25 @@ const routes: Routes = [
 	{ path: "publisher/:id", component: ImprintPageComponent },
 	{ path: "series/:id", component: SeriesPageComponent },
 	{ path: "search", component: SearchPageComponent },
-	{ path: "about", component: AboutPageComponent },
-	{ path: "faq", component: FaqPageComponent },
+	{
+		path: "about",
+		loadChildren: () => import("./about-page/about-page.component").then((m) => m.AboutPageComponent)
+	},
+	{
+		path: "faq",
+		loadChildren: () => import("./faq-page/faq-page.component").then((m) => m.FaqPageComponent)
+	},
 	{ path: "correction", component: DataCorrectionFormComponent },
 	{ path: "contact", component: ContactPageComponent },
-	{ path: "privacy", component: PrivacyPageComponent },
-	{ path: "guidelines", component: DatabaseGuidelinesComponent },
+	{
+		path: "privacy",
+		loadChildren: () => import("./privacy-page/privacy-page.component").then((m) => m.PrivacyPageComponent)
+	},
+	{
+		path: "guidelines",
+		loadChildren: () =>
+			import("./database-guidelines/database-guidelines.component").then((m) => m.DatabaseGuidelinesComponent)
+	},
 	{ path: "login", component: LoginPageComponent },
 	{ path: "login/authorized", component: LoginPageComponent, canActivate: [AuthenticationGuard] },
 	{ path: "settings", pathMatch: "full", component: UserSettingsPageComponent, canActivate: [AuthenticationGuard] },


### PR DESCRIPTION
<!-- 
    Thank you for contributing! 
    If you have not already, please review the contribution guidelines before submitting:
    https://github.com/Butterstroke/Myneworm/tree/master/.github/CONTRIBUTING.md
-->

## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Updating routing to allow for lazy loading of static page components like the privacy and FAQ pages.

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

Updated routing to use loadChildren and load components in when needed. Only the pages with loadChildren will not be loaded initially when accessing the site.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->

Internal#826