### PR TITLE
[Fix/831] Added Default Value if Release Date is Null

### DIFF
--- a/src/app/book-page/book-page.component.html
+++ b/src/app/book-page/book-page.component.html
@@ -10,7 +10,8 @@
             <div>
                 <p><strong>Format:</strong> {{this.utilities.formatReadable(book.format_name)}}</p>
                 <p><strong>Type:</strong> {{this.utilities.formatReadable(book.book_type_name)}}</p>
-                <p><strong>Release:</strong> {{this.utilities.dateReadable(book.release_date)}}</p>
+                <p *ngIf="book.release_date !== null"><strong>Release:</strong> {{this.utilities.dateReadable(book.release_date)}}</p>
+                <p *ngIf="book.release_date === null"><strong>Release:</strong> Unknown</p>
                 <p *ngIf="publisher != undefined"><strong>Imprint: </strong><a
                         routerLink="/publisher/{{book.publisher_id}}" class="aside-link">{{publisher.name}}</a></p>
             </div>


### PR DESCRIPTION
<!-- 
    Thank you for contributing! 
    If you have not already, please review the contribution guidelines before submitting:
    https://github.com/Butterstroke/Myneworm/tree/master/.github/CONTRIBUTING.md
-->

## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Adds additional template logic to display a `Release: Unknown` on the page if the book does not have a release date yet.

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

Added another p tag with an ngIf to display the Unknown if release date is null.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->

Internal#831