### PR TITLE
[Fix/834] Improved Navigation Bar to Fit Laptop-sized Widths

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -1,7 +1,7 @@
 .main-container {
-    min-height: calc(100vh - 190px); /* Header + Footer height ignored */
+    min-height: calc(100vh - 180px); /* Header + Footer height ignored */
     margin-top: 20px;
-    margin-bottom: 20px;
+    padding: 0;
 }
 
 footer {
@@ -11,7 +11,7 @@ footer {
     color: #ECEBF3;
     text-align: right;
     font-size: large;
-    clear: both;
+    margin-top: 10px;
 }
 
 footer span {

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -2,7 +2,7 @@
     Top navigation bar
 -->
 <nav class="nav-list navbar">
-    <div class="container-fluid nav-height">
+    <div class="container-fluid nav-height nav-main-div">
         <ul class="nav-list-ul">
             <li class="nav-li"><a class="nav-item nav-link navbar-brand" [routerLink]="'.'">Myneworm</a></li>
             <li class="nav-li"><a class="nav-item nav-link" [routerLink]="'/home'">Home</a></li>
@@ -10,6 +10,9 @@
             <li class="nav-li"><a class="nav-item nav-link" [routerLink]="'/contact'">Contact</a></li>
             <li class="nav-li"><a class="nav-item nav-link" [routerLink]="'/about'">About</a></li>
             <li class="nav-li"><a class="nav-item nav-link" [routerLink]="'/faq'">FAQ</a></li>
+            <li class="nav-li nav-search-link">
+                <a class="nav-item nav-link" [routerLink]="'/search'">Search</a>
+            </li>
         </ul>
         <div class="nav-list-right nav-height">
             <ul class="nav-list-ul">

--- a/src/app/home-page/home-page.component.html
+++ b/src/app/home-page/home-page.component.html
@@ -1,5 +1,3 @@
-<div class="home-page">
-    <div class="calendar-container">
-        <calendar-manager #calendar [options]="calendarOptions"></calendar-manager>
-    </div>
+<div class="calendar-container">
+    <calendar-manager #calendar [options]="calendarOptions"></calendar-manager>
 </div>

--- a/src/app/home-page/home-page.component.ts
+++ b/src/app/home-page/home-page.component.ts
@@ -49,7 +49,7 @@ export class HomePageComponent implements OnInit {
 		this.calendarOptions = {
 			plugins: [dayGridPlugin, interactionPlugin, listPlugin],
 			themeSystem: "standard",
-			height: "calc(100vh - 190px)",
+			height: "calc(100vh - 180px)",
 			initialView: "dayGridMonth",
 			dayMaxEventRows: 5,
 			buttonText: {

--- a/src/app/shared/navigation-bar.css
+++ b/src/app/shared/navigation-bar.css
@@ -1,5 +1,10 @@
+.nav-main-div {
+    flex-wrap: nowrap;
+    padding: 0;
+}
+
 .nav-list-right {
-    margin-right: 38px;
+    margin-right: clamp(10px, 2vw, 38px);
 }
 
 .nav-list {
@@ -33,8 +38,8 @@
 }
 
 .nav-item {
-    padding-left: 20px;
-    padding-right: 20px;
+    padding-left: clamp(15px, 1vw, 20px);
+    padding-right: clamp(15px, 1vw, 20px);
     font-size: x-large;
     display: flex;
     align-items: center;
@@ -65,4 +70,19 @@
 .nav-li:first-child > .nav-item {
     padding-left: clamp(30px, 3vw, 40px);
     padding-right: clamp(40px, 6vw, 80px);
+    margin-right: 0;
+}
+
+.nav-search-link {
+    display: none;
+}
+
+@media (max-width: 1350px) {
+    .nav-search-link {
+        display: inline-block;
+    }   
+
+    .nav-search {
+        display: none;
+    }
 }


### PR DESCRIPTION
<!-- 
    Thank you for contributing! 
    If you have not already, please review the contribution guidelines before submitting:
    https://github.com/Butterstroke/Myneworm/tree/master/.github/CONTRIBUTING.md
-->

## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Navigation bar is now responsive from ~1390px down to 1000px.

Also improved padding issues as both ends of the navigation bar got extra padding in the Bootstrap addition when they both shouldn't have.

Additionally, the search bar will be replaced with a link to the search page on widths smaller than 1350px

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

Updated CSS rules to reduce and fix padding in certain spots while also fixing an issue with flexboxes wrapping.

For the search bar, added new rule to display a link instead when the width is less than 1350px.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->

Internal#834