### PR TITLE
[Fix/842] Added Check To Not Display Location if Value is Null

### DIFF
--- a/src/app/user-profile-page/user-profile-page.component.html
+++ b/src/app/user-profile-page/user-profile-page.component.html
@@ -3,7 +3,7 @@
         <img src='{{getAvatar()}}'>
         <p><b>Last Online:</b> {{this.isOnlineText()}}</p>
         <p><b>Joined:</b> {{this.utilities.dateReadable(profileInfo.create_date)}}</p>
-        <p><b>Location:</b> {{profileInfo.location}}</p>
+        <p *ngIf="profileInfo.location"><b>Location:</b> {{profileInfo.location}}</p>
         <p *ngIf="profileInfo.birthday"><b>Birthday:</b> {{this.utilities.dateReadable(profileInfo.birthday)}}</p>
         <br>
         <a class="btn btn-lg myneworm-btn" role="button" href="./user/{{profileInfo.username}}/lists">My List</a>


### PR DESCRIPTION
<!-- 
    Thank you for contributing! 
    If you have not already, please review the contribution guidelines before submitting:
    https://github.com/Butterstroke/Myneworm/tree/master/.github/CONTRIBUTING.md
-->

## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Prevents the location section of the user profile to be displayed if there is no location value to display.

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

Added an ngIf to the p tag for the location section.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->

Internal#842