### PR TITLE
[Feature/812] Updated Images to Use New Size Routing

### DIFF
--- a/src/app/book-page/book-page.component.html
+++ b/src/app/book-page/book-page.component.html
@@ -2,7 +2,7 @@
     <h2 class="page-title">{{book.title}}</h2>
     <div class="row">
         <aside class="col-2 aside-content">
-            <img class="book-cover" src='{{getCover(book.isbn)}}'>
+            <img class="book-cover" src='{{getCover()}}' alt='Cover for {{book.title}}'>
             <div class="aside-btn-group">
                 <a class="btn btn-lg myneworm-btn disabled" tabindex="-1" role="button" aria-disabled="true">Add to List</a>
                 <a [routerLink]="'/correction'" [queryParams]="{isbn: book.isbn}" class="btn btn-lg myneworm-btn disabled" tabindex="-1" role="button" aria-disabled="true">Edit Entry</a>

--- a/src/app/book-page/book-page.component.ts
+++ b/src/app/book-page/book-page.component.ts
@@ -48,7 +48,7 @@ export class BookPageComponent implements OnInit {
 		});
 	}
 
-	getCover(isbn: string) {
-		return this.service.getAsset(`${isbn}`);
+	getCover() {
+		return this.service.getCover(this.book.isbn, "large");
 	}
 }

--- a/src/app/models/AssetSize.ts
+++ b/src/app/models/AssetSize.ts
@@ -1,0 +1,7 @@
+export const AssetSize = {
+	original: "original",
+	large: "large",
+	medium: "medium",
+	small: "small",
+	thumbnail: "thumbnail"
+};

--- a/src/app/search-bar/search-bar.component.html
+++ b/src/app/search-bar/search-bar.component.html
@@ -11,7 +11,7 @@
     <table *ngIf="dataSource" mat-table [dataSource]="dataSource" multiTemplateDataRows class="mat-elevation-z8 search-table" cellspacing="0">
         <ng-container matColumnDef="cover">
             <td class="search-image-row" mat-cell *matCellDef="let element">
-                <img class="search-cover-img" src='{{this.service.getAsset(element.isbn)}}' alt='Cover for {{element.title}}' />
+                <img class="search-cover-img" src='{{getCover(element.isbn)}}' alt='Cover for {{element.title}}' />
             </td>
         </ng-container>
         <ng-container matColumnDef="title">

--- a/src/app/search-bar/search-bar.component.ts
+++ b/src/app/search-bar/search-bar.component.ts
@@ -17,7 +17,11 @@ export class SearchBarComponent {
 	loading = false;
 	hoveredRow: BookData | null = null;
 
-	constructor(public service: MynewormAPIService, public utilities: UtilitiesService, private router: Router) {}
+	constructor(
+		private service: MynewormAPIService,
+		public utilities: UtilitiesService,
+		private router: Router
+	) {}
 
 	private searchBooks() {
 		if (this.searchTerm === "") {
@@ -27,6 +31,10 @@ export class SearchBarComponent {
 			this.dataSource = new MatTableDataSource<BookData>(data);
 			this.loading = false;
 		});
+	}
+
+	getCover(isbn: string) {
+		return this.service.getCover(isbn, "thumbnail");
 	}
 
 	submit() {

--- a/src/app/search-page/search-page.component.html
+++ b/src/app/search-page/search-page.component.html
@@ -37,7 +37,7 @@
         <ng-container matColumnDef="cover">
             <td class="search-image-row" mat-cell *matCellDef="let element">
                 <a routerLink="/book/{{element.isbn}}"><img class="search-cover-img"
-                        src='{{this.service.getAsset(element.isbn)}}' alt='Cover for {{element.title}}' /></a>
+                        src='{{getCover(element.isbn)}}' alt='Cover for {{element.title}}' /></a>
             </td>
         </ng-container>
         <ng-container matColumnDef="title">

--- a/src/app/search-page/search-page.component.ts
+++ b/src/app/search-page/search-page.component.ts
@@ -21,7 +21,7 @@ export class SearchPageComponent implements OnInit {
 
 	constructor(
 		private route: ActivatedRoute,
-		public service: MynewormAPIService,
+		private service: MynewormAPIService,
 		public utilities: UtilitiesService,
 		private metaService: MetadataService,
 		private router: Router,
@@ -90,5 +90,9 @@ export class SearchPageComponent implements OnInit {
 
 		this.pageNumber--;
 		this.updateQuery();
+	}
+
+	getCover(isbn: string) {
+		return this.service.getCover(isbn, "small");
 	}
 }

--- a/src/app/services/myneworm-api.service.ts
+++ b/src/app/services/myneworm-api.service.ts
@@ -12,6 +12,7 @@ import { UserStatisticsProfile } from "../models/userStatisticsData";
 import { RegistrationData } from "../models/RegistrationData";
 import { ProfileUpdateData } from "../models/profileUpdateData";
 import { AccountUpdateData } from "../models/accountUpdateData";
+import { AssetSize } from "../models/AssetSize";
 
 @Injectable({
 	providedIn: "root"
@@ -49,6 +50,14 @@ export class MynewormAPIService {
 
 	getAsset(localPath: string) {
 		return `${environment.API_ADDRESS}/asset/${localPath}`;
+	}
+
+	getCover(isbn: string, size: string) {
+		if (!Object.keys(AssetSize).includes(size)) {
+			return null;
+		}
+
+		return `${environment.API_ADDRESS}/asset/cover/${isbn}?size=${size}`;
 	}
 
 	getPublisher(publisherID: string) {

--- a/src/app/user-list-page/table-display/table-display.component.html
+++ b/src/app/user-list-page/table-display/table-display.component.html
@@ -5,8 +5,8 @@
             <th mat-header-cell *matHeaderCellDef scope="col" [attr.role]="null"></th>
             <td mat-cell *matCellDef="let element" class="row-padding col-1">
                 <div class="cover-wrapper">
-                    <img class="table-img" src='{{this.getCover(element.isbn)}}' alt='Cover for {{element.title}}' />
-                    <img class="hover-preview" src='{{this.getCover(element.isbn)}}' alt='' />
+                    <img class="table-img" src='{{getThumbnail(element.isbn)}}' alt='Cover for {{element.title}}' />
+                    <img class="hover-preview" src='{{getPreview(element.isbn)}}' alt='' />
                 </div>
             </td>
         </ng-container>

--- a/src/app/user-list-page/table-display/table-display.component.ts
+++ b/src/app/user-list-page/table-display/table-display.component.ts
@@ -22,7 +22,7 @@ export class TableDisplayComponent implements OnInit, OnChanges {
 	formatDateString = formatDateString;
 	public listEntries: ListEntry[];
 
-	constructor(public service: MynewormAPIService) {}
+	constructor(private service: MynewormAPIService) {}
 
 	ngOnInit() {
 		this.listEntries = this._allEntries.data;
@@ -49,6 +49,14 @@ export class TableDisplayComponent implements OnInit, OnChanges {
 
 	getCover(isbn: string) {
 		return this.service.getAsset(`${isbn}`);
+	}
+
+	getThumbnail(isbn: string) {
+		return this.service.getCover(isbn, "thumbnail");
+	}
+
+	getPreview(isbn: string) {
+		return this.service.getCover(isbn, "small");
 	}
 
 	sortData(sort: Sort) {

--- a/src/app/user-list-page/user-list-page.component.ts
+++ b/src/app/user-list-page/user-list-page.component.ts
@@ -35,7 +35,7 @@ export class UserListPageComponent {
 
 	constructor(
 		private route: ActivatedRoute,
-		public service: MynewormAPIService,
+		private service: MynewormAPIService,
 		private metaService: MetadataService,
 		private utilities: UtilitiesService
 	) {


### PR DESCRIPTION
<!-- 
    Thank you for contributing! 
    If you have not already, please review the contribution guidelines before submitting:
    https://github.com/Butterstroke/Myneworm/tree/master/.github/CONTRIBUTING.md
-->

## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Images will now request based on size of need instead of the original file on the API server. This leads to less data being requested overall and might speed up requests depending on connection speed and amount of data.

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

Added a new function to the Myneworm-API service to allow size input for the link. Then, went around the codebase updating existing cover links to use the new function.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->

Internal#812