### PR TITLE
[Feature/840] Updated Login and Registration Page with Toast Notifications

### DIFF
--- a/src/app/login-page/login-page.component.css
+++ b/src/app/login-page/login-page.component.css
@@ -5,17 +5,6 @@
     align-items: center;
 }
 
-.error-message {
-    background-color: rgba(240, 45, 58, 0.3);
-    width: clamp(220px, 50%, 400px);
-    height: 40px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    border-radius: 6px;
-    color: #E5101E;
-}
-
 .login-form {
     display: flex;
     flex-direction: column;
@@ -45,11 +34,9 @@ a.login-button {
     cursor: pointer;
 }
 
-.login-input {
-    width: calc(100% - 16px);
-    height: 30px;
-    padding-left: 6px;
-    padding-right: 6px;
+input:focus {
+    border-color: var(--bs-border-color);
+    box-shadow: none;
 }
 
 .login-label {

--- a/src/app/login-page/login-page.component.html
+++ b/src/app/login-page/login-page.component.html
@@ -1,19 +1,18 @@
 <div class="login-container">
     <h1>Login</h1>
     <form class="login-form" #loginForm="ngForm" (ngSubmit)="submit()">
-        <div class="error-message" *ngIf="this.err !== ''">{{this.err}}</div>
         <div class="login-form-div">
             <label class="login-label" for="username"><strong>Username</strong></label>
-            <input type="text" class="login-input" id="login" name="login" placeholder="Username" required
+            <input type="text" class="form-control" id="login" name="login" placeholder="Username" required
                 [(ngModel)]="login.username" #username="ngModel" />
         </div>
         <div class="login-form-div">
             <label class="login-label" for="password"><strong>Password</strong></label>
-            <input type="password" class="login-input" name="password" required placeholder="Password"
+            <input type="password" class="form-control" name="password" required placeholder="Password"
                 [(ngModel)]="login.password" #password="ngModel" />
         </div>
         <button class="btn myneworm-btn login-button" type="submit">Login</button>
     </form>
-    <button class="btn myneworm-btn login-button" type="button">Forgot Password?</button>
+    <button class="btn myneworm-btn login-button disabled" type="button" aria-disabled="true" tabindex="-1">Forgot Password?</button>
     <a [routerLink]="'/register'" class="btn myneworm-btn login-button" role="button">Register</a>
 </div>

--- a/src/app/login-page/login-page.component.ts
+++ b/src/app/login-page/login-page.component.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute, Router } from "@angular/router";
 import { loginForm } from "src/app/models/loginForm";
 import { AuthenticationService } from "src/app/services/authentication/authentication.service";
 import { MetadataService } from "src/app/services/metadata.service";
+import { ToastService } from "../services/toast.service";
 
 @Component({
 	selector: "login-page",
@@ -13,13 +14,13 @@ export class LoginPageComponent {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	@ViewChild("loginForm") dataForm: any;
 	login = new loginForm();
-	public err = "";
 
 	constructor(
 		private route: ActivatedRoute,
 		private router: Router,
 		private authService: AuthenticationService,
-		private metaService: MetadataService
+		private metaService: MetadataService,
+		private toastService: ToastService
 	) {
 		this.metaService.updateMetaTags("Login", "/login");
 	}
@@ -31,7 +32,7 @@ export class LoginPageComponent {
 			}
 
 			if (params.state === "expired") {
-				this.err = "Session expired. Please reauthenticate.";
+				this.toastService.sendError("Session expired. Please reauthenticate.");
 			}
 
 			this.router.navigate([], { relativeTo: this.route });
@@ -49,17 +50,16 @@ export class LoginPageComponent {
 			this.login.password === undefined ||
 			this.login.password === ""
 		) {
-			this.err = "Missing username or password";
+			this.toastService.sendError("Failed to login. Missing username or password");
 			return;
 		}
 
 		this.authService.login(this.login.username, this.login.password).subscribe((data) => {
 			if (typeof data === "string") {
-				this.err = data;
+				this.toastService.sendError(data);
 				return;
 			}
 
-			this.err = "";
 			this.router.navigate(["/home"]);
 		});
 	}

--- a/src/app/registration-page/registration-page.component.html
+++ b/src/app/registration-page/registration-page.component.html
@@ -2,7 +2,6 @@
     <div class="col-6 flex-form">
         <h2>Sign Up</h2>
         <form (ngSubmit)="submit()" #registerForm="ngForm">
-            <div class="alert alert-danger form-alert align-center" *ngIf="APIErrResponse !== ''">Error: {{APIErrResponse}}</div>
             <div class="form-group group-margin">
                 <label for="username">Username<span class="required-mark">*</span></label>
                 <input type="text" class="form-control" id="username" name="username" 

--- a/src/app/registration-page/registration-page.component.ts
+++ b/src/app/registration-page/registration-page.component.ts
@@ -5,6 +5,7 @@ import { RegistrationData } from "../models/RegistrationData";
 import * as moment from "moment";
 import { catchError, of } from "rxjs";
 import { Router } from "@angular/router";
+import { ToastService } from "../services/toast.service";
 
 @Component({
 	selector: "registration-page",
@@ -16,9 +17,13 @@ export class RegistrationPageComponent {
 	usernameMatch = false;
 	confirmedPassword = false;
 	validBirthday = false;
-	APIErrResponse = "";
 
-	constructor(private service: MynewormAPIService, private router: Router, private metaService: MetadataService) {
+	constructor(
+		private service: MynewormAPIService,
+		private router: Router,
+		private metaService: MetadataService,
+		private toastService: ToastService
+	) {
 		this.metaService.updateMetaTags("Registration", "/register");
 	}
 
@@ -27,7 +32,7 @@ export class RegistrationPageComponent {
 			.registerUser(this.registrationForm)
 			.pipe(
 				catchError((err) => {
-					this.APIErrResponse = err.error.errors;
+					this.toastService.sendError(err.error.errors);
 					return of(null);
 				})
 			)
@@ -35,7 +40,8 @@ export class RegistrationPageComponent {
 				if (data === null) {
 					return;
 				}
-				// Add message to showcase success at login page.
+
+				this.toastService.sendSuccess("Created account! Please login to continue.");
 				this.router.navigate(["/login"]);
 			});
 	}


### PR DESCRIPTION
<!-- 
    Thank you for contributing! 
    If you have not already, please review the contribution guidelines before submitting:
    https://github.com/Butterstroke/Myneworm/tree/master/.github/CONTRIBUTING.md
-->

## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Updated Login and Registration Pages with Toast Notifications.

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

Using the existing ToastService, moved all errors and success messages for those respective pages to trigger toast notifications instead. Then, removed any existing general notification area for the components.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->

Internal#840