### PR TITLE
[Fix/866] Updated Settings Page to Use Null Values Instead of Empty Strings

### DIFF
--- a/src/app/user-settings-page/user-settings-page.component.ts
+++ b/src/app/user-settings-page/user-settings-page.component.ts
@@ -125,9 +125,9 @@ export class UserSettingsPageComponent implements OnInit {
 		if (!this.profileForm.pristine) {
 			this.service
 				.updateProfile({
-					about_me: this.profileData.about_me,
-					display_name: this.profileData.display_name,
-					location: this.profileData.location,
+					about_me: this.profileData.about_me === "" ? null : this.profileData.about_me,
+					display_name: this.profileData.display_name === "" ? null : this.profileData.display_name,
+					location: this.profileData.location === "" ? null : this.profileData.location,
 					displaybirthday: this.profileData.displaybirthday
 				})
 				// eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
<!-- 
    Thank you for contributing! 
    If you have not already, please review the contribution guidelines before submitting:
    https://github.com/Butterstroke/Myneworm/tree/master/.github/CONTRIBUTING.md
-->

## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Updates the backend logic for the user settings page to use null values instead of empty strings as this causes issues with the API and does not clear the selected values back to null.

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

Added checks to the data body to see if the input is an empty string or not. If so, use null instead.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->

Internal#866