### PR TITLE
[Fix/871] Fixed Issue With Multiple Avatar Keys in Profile Form

### DIFF
--- a/src/app/user-settings-page/user-settings-page.component.ts
+++ b/src/app/user-settings-page/user-settings-page.component.ts
@@ -84,6 +84,7 @@ export class UserSettingsPageComponent implements OnInit {
 			return this.toastService.sendError("Only images are supported");
 		}
 
+		this.avatarForm.delete("KS-Myneworm");
 		this.avatarForm.append("KS-Myneworm", files[0]);
 
 		const reader = new FileReader();


### PR DESCRIPTION
<!-- 
    Thank you for contributing! 
    If you have not already, please review the contribution guidelines before submitting:
    https://github.com/Butterstroke/Myneworm/tree/master/.github/CONTRIBUTING.md
-->

## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Fixes issue where multiple uploads causes multiple files to be send to the API and fail to save the requested file.

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

Added an additional line to clear the form data before adding a new file buffer.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->

Internal#871