### PR TITLE
[Fix/862 & Fix/869] Updated Styles to Accommodate Larger Resolutions + Fix Margins

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -29,6 +29,6 @@ footer span:last-child {
     top: 20px
 }
 
-::ng-deep router-outlet + * > div {
+.router-wrapper {
     margin-top: 20px;
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -33,8 +33,10 @@
 <div class="container-fluid main-container">
     <div class="toast-wrapper-div">
         <toast-messages></toast-messages>
-    </div>    
-    <router-outlet></router-outlet>
+    </div>  
+    <div class="router-wrapper">
+        <router-outlet></router-outlet>
+    </div>  
 </div>
 <footer>
     <span><a class="btn-link" [routerLink]="'/privacy'">Privacy</a></span>

--- a/src/app/shared/list-entry-modal/list-entry-modal.component.css
+++ b/src/app/shared/list-entry-modal/list-entry-modal.component.css
@@ -1,13 +1,22 @@
 .list-entry-modal {
     padding: 2% 3%;
-    height: -webkit-fill-available;
-    width: -webkit-fill-available;
+    height: 100%;
     background-color: #ECEBF3;
     color: #1F2232;
 }
 
+.modal-label {
+    font-size: 0.941vw;
+}
+
+@media screen and (max-width: 1024px) {
+    .modal-label {
+        font-size: 1.563vw;
+    }
+}
+
 .modal-content {
-    height: 84%;
+    height: calc(60vh - 135px);
     justify-content: space-between;
 }
 
@@ -37,10 +46,6 @@
     border: none !important;
     -webkit-text-fill-color: inherit !important;
     box-shadow: none;
-}
-
-.modal-footer {
-    width: -webkit-fill-available;
 }
 
 .datepicker-input {
@@ -79,7 +84,7 @@
 }
 
 .form-group:nth-child(n+2) {
-    margin-top: 15px;
+    margin-top: 10px;
 }
 
 ::ng-deep.mat-calendar-body-today:not(.mat-calendar-body-selected):not(.mat-calendar-body-comparison-identical) {
@@ -98,10 +103,8 @@
 .img-aspect-ratio {
     width: 100%;
     display: block;
-    height: auto;
-    max-height: 385px;
 }
 
 .modal-input-textarea {
-    max-height: 120px;
+    max-height: calc(46vh - 315px);
 }

--- a/src/app/shared/list-entry-modal/list-entry-modal.component.html
+++ b/src/app/shared/list-entry-modal/list-entry-modal.component.html
@@ -13,19 +13,19 @@
                 </div>
                 <div class="form-group row">
                     <div class="col-6">
-                        <label for="score">Score</label>
+                        <label for="score" class="modal-label">Score</label>
                         <input type="number" class="form-control modal-input" id="score" name="score" min="1" max="10"
                             [(ngModel)]="listEntryForm.score" (input)="validateScore()">
                     </div>
                     <div class="col-6">
-                        <label for="reread">Reread</label>
+                        <label for="reread" class="modal-label">Reread</label>
                         <input type="number" class="form-control modal-input" id="reread" name="reread" min="1"
                             [(ngModel)]="listEntryForm.reread" (input)="validateReread()">
                     </div>
                 </div>
                 <div class="form-group row">
                     <div class="col-6">
-                        <label for="activity">Status</label>
+                        <label for="activity" class="modal-label">Status</label>
                         <select class="form-select modal-input" id="activity" name="activity"
                             [(ngModel)]="listEntryForm.active_status">
                             <option *ngFor="let status of activityStatus | keyvalue" [ngValue]="status.value">
@@ -33,7 +33,7 @@
                         </select>
                     </div>
                     <div class="col-6">
-                        <label for="ownership">Ownership</label>
+                        <label for="ownership" class="modal-label">Ownership</label>
                         <select class="form-select modal-input" id="ownership" name="ownership"
                             [(ngModel)]="listEntryForm.owner_status">
                             <option value=""></option>
@@ -44,7 +44,7 @@
                 </div>
                 <div class="form-group row">
                     <div class="col-6" (focusout)="removeDateDisplay(0)">
-                        <label for="startDate">Start Date</label>
+                        <label for="startDate" class="modal-label">Start Date</label>
                         <div class="datepicker-input">
                             <img src="/assets/fa-calendar-dark.svg" class="date-icon" />
                             <input type="text" autocomplete="off" aria-autocomplete="none"
@@ -57,7 +57,7 @@
                         </mat-card>
                     </div>
                     <div class="col-6" (focusout)="removeDateDisplay(1)">
-                        <label for="endDate">End Date</label>
+                        <label for="endDate" class="modal-label">End Date</label>
                         <div class="datepicker-input">
                             <img src="/assets/fa-calendar-dark.svg" class="date-icon" />
                             <input type="text" autocomplete="off" aria-autocomplete="none"
@@ -71,7 +71,7 @@
                     </div>
                 </div>
                 <div class="form-group row">
-                    <label for="notes">Notes</label>
+                    <label for="notes" class="modal-label">Notes</label>
                     <div class="col-12">
                         <textarea rows="3" class="form-control modal-input modal-input-textarea" id="notes" name="notes"
                             autocomplete="off" aria-autocomplete="none" [(ngModel)]="listEntryForm.notes"></textarea>


### PR DESCRIPTION
<!-- 
    Thank you for contributing! 
    If you have not already, please review the contribution guidelines before submitting:
    https://github.com/Butterstroke/Myneworm/tree/master/.github/CONTRIBUTING.md
-->

## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Updates the styles to accommodate for larger resolutions in the ListEntryModal. Also updated the main site to fix the margin-top for the page contents.

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

Updated the ListEntryModal styles to be more flexible for heights and removed various properties that cause image squish or hard to read text at resolutions >1440px.

For the margin-top, the router-outlet was wrapped in a parent div and that div was styled with the `margin-top` property.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->

Internal#862 & Internal#869