### PR TITLE
[Fix/876] Updated Error Message For Login Credentials If Invalid

### DIFF
--- a/src/app/services/authentication/authentication.service.ts
+++ b/src/app/services/authentication/authentication.service.ts
@@ -9,7 +9,10 @@ import { LocalCookiesService } from "./local-cookies.service";
 	providedIn: "root"
 })
 export class AuthenticationService {
-	constructor(private http: HttpClient, private cookieService: LocalCookiesService) {}
+	constructor(
+		private http: HttpClient,
+		private cookieService: LocalCookiesService
+	) {}
 
 	login(username: string, password: string) {
 		return this.http
@@ -38,6 +41,9 @@ export class AuthenticationService {
 					return of(`ERROR (500): Response was valid but data was not received.`);
 				}),
 				catchError((error) => {
+					if (error.status === 401) {
+						return of("Username or password is invalid");
+					}
 					return of(`ERROR (${error.status}): ${error.statusText}`);
 				})
 			);


### PR DESCRIPTION
<!-- 
    Thank you for contributing! 
    If you have not already, please review the contribution guidelines before submitting:
    https://github.com/Butterstroke/Myneworm/tree/master/.github/CONTRIBUTING.md
-->

## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Updates the authentication service to use the "Username or password is invalid" message instead of doing a 401 unauthorized error on login.

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

Added a check in the catchError function to look for 401 errors and then return a static string instead.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->

Internal#876