### PR TITLE
[Fix/886] Fixed Check to Show Description Backup on Book Page

### DIFF
--- a/src/app/book-page/book-page.component.html
+++ b/src/app/book-page/book-page.component.html
@@ -22,8 +22,8 @@
         </aside>
         <main class="col-8">
             <div class="book-description">
-                <p *ngIf="book.description != ''" [innerHTML]="book.description"></p>
-                <p *ngIf="book.description === ''">No description available.</p>
+                <p *ngIf="book.description !== '' && book.description !== null" [innerHTML]="book.description"></p>
+                <p *ngIf="book.description === '' || book.description === null">No description available.</p>
             </div>
         </main>
     </div>


### PR DESCRIPTION
<!-- 
    Thank you for contributing! 
    If you have not already, please review the contribution guidelines before submitting:
    https://github.com/Butterstroke/Myneworm/tree/master/.github/CONTRIBUTING.md
-->

## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Fixes check on the book page to display the message "No description available" if the value is null instead of ''.

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

Added checks for null values and boolean operators to make sure only one p tag is shown on the page.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->

Internal#886