### PR TITLE
[Feature/878] Updated Entry Button on Book Page to Display Add or Update

### DIFF
--- a/src/app/book-page/book-page.component.html
+++ b/src/app/book-page/book-page.component.html
@@ -4,15 +4,14 @@
         <aside class="col-2 aside-content">
             <img class="book-cover" src='{{getCover()}}' alt='Cover for {{book.title}}'>
             <div class="aside-btn-group">
-                <a class="btn btn-lg myneworm-btn" role="button" (click)="updateListEntry()" [ngClass]="{ disabled: isLoggedIn }"
-                    [attr.aria-disabled]="isLoggedIn" tabindex='{{isLoggedIn ? -1 : 0}}'>Add to List</a>
+                <a class="btn btn-lg myneworm-btn" role="button" (click)="updateListEntry()" [ngClass]="{ disabled: !isLoggedIn }"
+                    [attr.aria-disabled]="!isLoggedIn" tabindex='{{isLoggedIn ? 0 : -1}}'>{{ hasExistingEntry ? 'Update List' : 'Add to List' }}</a>
                 <a [routerLink]="'/correction'" [queryParams]="{isbn: book.isbn}" class="btn btn-lg myneworm-btn disabled" tabindex="-1" role="button" aria-disabled="true">Edit Entry</a>
             </div>
             <div>
                 <p><strong>Format:</strong> {{this.utilities.formatReadable(book.format_name)}}</p>
                 <p><strong>Type:</strong> {{this.utilities.formatReadable(book.book_type_name)}}</p>
-                <p *ngIf="book.release_date !== null"><strong>Release:</strong> {{this.utilities.dateReadable(book.release_date)}}</p>
-                <p *ngIf="book.release_date === null"><strong>Release:</strong> Unknown</p>
+                <p><strong>Release:</strong> {{ book.release_date !== null ? this.utilities.dateReadable(book.release_date) : 'Unknown' }}</p>
                 <p *ngIf="publisher != undefined"><strong>Imprint: </strong><a
                         routerLink="/publisher/{{book.publisher_id}}" class="aside-link">{{publisher.name}}</a></p>
             </div>

--- a/src/app/shared/list-entry-modal/list-entry-modal.component.ts
+++ b/src/app/shared/list-entry-modal/list-entry-modal.component.ts
@@ -146,7 +146,7 @@ export class ListEntryModalComponent {
 			this.service
 				.updateListEntry(this.bookData.isbn, this.listEntryForm)
 				.pipe(
-					catchError((err) => {
+					catchError(() => {
 						this.toastService.sendError("Unknown error response. Unable to update entry.");
 						return of(null);
 					})
@@ -157,7 +157,7 @@ export class ListEntryModalComponent {
 					}
 
 					this.toastService.sendSuccess("Updated entry!");
-					this.dialogRef.close();
+					this.close();
 				});
 			return;
 		}
@@ -165,7 +165,7 @@ export class ListEntryModalComponent {
 		this.service
 			.addListEntry(this.bookData.isbn, this.listEntryForm)
 			.pipe(
-				catchError((err) => {
+				catchError(() => {
 					this.toastService.sendError("Unknown error response. Unable to save entry.");
 					return of(null);
 				})
@@ -176,8 +176,16 @@ export class ListEntryModalComponent {
 				}
 
 				this.toastService.sendSuccess("Added entry!");
-				this.dialogRef.close();
+				this.close();
 			});
+	}
+
+	close(isDeleted = false) {
+		if (isDeleted) {
+			this.dialogRef.close(null);
+			return;
+		}
+		this.dialogRef.close(this.listEntryForm);
 	}
 
 	deleteEntry() {
@@ -200,7 +208,7 @@ export class ListEntryModalComponent {
 				}
 
 				this.toastService.sendSuccess("Entry removed from list");
-				this.dialogRef.close();
+				this.close(true);
 			});
 	}
 }


### PR DESCRIPTION
<!-- 
    Thank you for contributing! 
    If you have not already, please review the contribution guidelines before submitting:
    https://github.com/Butterstroke/Myneworm/tree/master/.github/CONTRIBUTING.md
-->

## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

The button now switches between 'Add to List' and 'Update List' depending on if the authenticated user has a list entry for the target book or not.

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

Updated the book page component with a new boolean variable to keep track if the user has a list entry or not. Also updated the ListEntryModal to return data if the entry was deleted or not. The boolean variable on book page will update when the dialog is closed.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->

Internal#878