### PR TITLE
[Feature/850] Added Functionality to Delete Button

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -31,6 +31,7 @@ import { UserProfilePageComponent } from "./user-profile-page/user-profile-page.
 import { StatisticDisplayComponent } from "./user-profile-page/statistic-display/statistic-display.component";
 import { RegistrationPageComponent } from "./registration-page/registration-page.component";
 import { SharedModule } from "./shared/shared.module";
+import { DeleteConfirmationComponent } from "./user-settings-page/delete-confirmation/delete-confirmation.component";
 
 @NgModule({
 	declarations: [
@@ -43,7 +44,8 @@ import { SharedModule } from "./shared/shared.module";
 		UserSettingsPageComponent,
 		UserProfilePageComponent,
 		StatisticDisplayComponent,
-		RegistrationPageComponent
+		RegistrationPageComponent,
+		DeleteConfirmationComponent
 	],
 	imports: [
 		BrowserModule,

--- a/src/app/services/myneworm-api.service.ts
+++ b/src/app/services/myneworm-api.service.ts
@@ -155,6 +155,14 @@ export class MynewormAPIService {
 		);
 	}
 
+	deleteUser() {
+		return this.http.delete(`${environment.API_ADDRESS}/user`, {
+			withCredentials: true,
+			observe: "body",
+			responseType: "json"
+		});
+	}
+
 	getListEntry(isbn: string, userID: string) {
 		return this.http.get<ListEntry>(`${environment.API_ADDRESS}/lists/${isbn}/${userID}`);
 	}

--- a/src/app/user-settings-page/delete-confirmation/delete-confirmation.component.css
+++ b/src/app/user-settings-page/delete-confirmation/delete-confirmation.component.css
@@ -1,0 +1,18 @@
+.confirmation-message {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 6%;
+}
+
+.confirmation-content {
+    display: flex;
+    flex-direction: column;
+    text-align: center;
+}
+
+.confirmation-btns {
+    display: flex;
+    justify-content: space-around;
+}

--- a/src/app/user-settings-page/delete-confirmation/delete-confirmation.component.html
+++ b/src/app/user-settings-page/delete-confirmation/delete-confirmation.component.html
@@ -1,0 +1,11 @@
+<div class="confirmation-message">
+    <h1>Are you sure?</h1>
+    <div class="confirmation-content">
+        <p>Logging back into your account within seven (7) days will reverse this action.</p>
+        <p>After the account is deleted, <span style="color: red;">there is no data recovery.</span></p>
+        <div class="confirmation-btns">
+            <button class="btn btn-lg btn-danger" (click)="deleteAccount()">Delete My Account</button>
+            <button class="btn btn-lg myneworm-btn" (click)="close()">Cancel Action</button>
+        </div>
+    </div>
+</div>

--- a/src/app/user-settings-page/delete-confirmation/delete-confirmation.component.spec.ts
+++ b/src/app/user-settings-page/delete-confirmation/delete-confirmation.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+
+import { DeleteConfirmationComponent } from "./delete-confirmation.component";
+
+describe("DeleteConfirmationComponent", () => {
+	let component: DeleteConfirmationComponent;
+	let fixture: ComponentFixture<DeleteConfirmationComponent>;
+
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+			declarations: [DeleteConfirmationComponent]
+		}).compileComponents();
+
+		fixture = TestBed.createComponent(DeleteConfirmationComponent);
+		component = fixture.componentInstance;
+		fixture.detectChanges();
+	});
+
+	it("should create", () => {
+		expect(component).toBeTruthy();
+	});
+});

--- a/src/app/user-settings-page/delete-confirmation/delete-confirmation.component.ts
+++ b/src/app/user-settings-page/delete-confirmation/delete-confirmation.component.ts
@@ -1,0 +1,48 @@
+import { Component } from "@angular/core";
+import { MatDialogRef } from "@angular/material/dialog";
+import { catchError, of } from "rxjs";
+import { MynewormAPIService } from "src/app/services/myneworm-api.service";
+import { ToastService } from "src/app/services/toast.service";
+
+@Component({
+	selector: "delete-confirmation",
+	templateUrl: "./delete-confirmation.component.html",
+	styleUrls: ["./delete-confirmation.component.css"]
+})
+export class DeleteConfirmationComponent {
+	constructor(
+		private service: MynewormAPIService,
+		private toastService: ToastService,
+		private dialogRef: MatDialogRef<DeleteConfirmationComponent>
+	) {}
+
+	deleteAccount() {
+		this.service
+			.deleteUser()
+			.pipe(
+				catchError((err) => {
+					console.error(err);
+					this.toastService.sendError("Failed to mark account for deletion. Server issue, try again later.");
+					return of(null);
+				})
+			)
+			.subscribe((data: object | null) => {
+				if (data === null) {
+					this.close();
+					return;
+				}
+
+				this.close(true);
+			});
+	}
+
+	close(deleted = false) {
+		if (deleted) {
+			this.toastService.sendSuccess("Successfully marked your account for deletion.");
+			this.dialogRef.close(true);
+			return;
+		}
+
+		this.dialogRef.close(false);
+	}
+}

--- a/src/app/user-settings-page/user-settings-page.component.html
+++ b/src/app/user-settings-page/user-settings-page.component.html
@@ -88,7 +88,7 @@
                     <input type="password" class="settings-input form-control" id="password" name="password"
                         pattern="(?=.*[0-9])(?=.*[!@#$%^&*])[a-zA-Z0-9!@#$%^&*]{8,}" placeholder="New Password"
                         aria-placeholder="New Password" [(ngModel)]="accountData.password">
-                    <input type="password" class="settings-input form-control" id="password" name="password"
+                    <input type="password" class="settings-input form-control" id="confirm" name="confirm"
                         pattern="(?=.*[0-9])(?=.*[!@#$%^&*])[a-zA-Z0-9!@#$%^&*]{8,}" placeholder="Confirm Password"
                         aria-placeholder="Confirm Password" [(ngModel)]="accountData.confirm">
                 </div>
@@ -109,14 +109,13 @@
             <br>
             <h3>Delete Your Account</h3>
             <div class="settings-subdiv">
-                <!--<p>By clicking this button, your account will be flagged for deletion. You will have up to 5 days after
-                    submission to revert this change. Afterwards, your account will be deleted and there is no recovery
-                    beyond the grace period.</p>-->
-                <p>Please send an email to <a href="mailto:myneworm@katsurin.com">myneworm@katsurin.com</a>,
-                    from the email linked to your account, requesting your account be deleted. You will have up to 5 days
-                    after to revert this change. Once your account is deleted, there is no recovery.</p>
-                <button class="btn btn-lg btn-danger settings-button delete-button disabled"
-                    aria-disabled="true" tabindex="-1">Delete</button>
+                <p style="color: red;">This will permanently delete your account!</p>
+                <p>
+                    By clicking this button, your account will be flagged for deletion. You will have up to seven (7) days after 
+                    submission to revert this change by logging back into your account. After the grace period and your account
+                    is deleted, there is no data recovery.
+                </p>
+                <button class="btn btn-lg btn-danger settings-button delete-button" (click)="deleteAccount()">Delete</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
<!-- 
    Thank you for contributing! 
    If you have not already, please review the contribution guidelines before submitting:
    https://github.com/Butterstroke/Myneworm/tree/master/.github/CONTRIBUTING.md
-->

## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Users can now delete their accounts on demand by clicking the delete button in their settings.

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

Updated the delete button area on the page to list exactly what to expect during the deletion process. Then implemented the button to open a dialog menu to force users to confirm their choice as well as reinforce what will happen with the account and the process. On confirmation, the user is logged out of the account and redirected back to the home page.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->

Internal#850