### PR TITLE
[Fix/860] Fixed Profile Statistics Display From Not Show Statistics

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -13,15 +13,11 @@ import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
 import { ImprintIndexModule } from "./imprint-index/imprint-index.module";
 import { MissingPageComponent } from "./missing-page/missing-page.component";
 import { SeriesPageModule } from "./series-page/series-page.module";
-import { FaqPageComponent } from "./faq-page/faq-page.component";
-import { AboutPageComponent } from "./about-page/about-page.component";
 import { SearchBarModule } from "./search-bar/search-bar.module";
 import { DataCorrectionFormComponent } from "./data-correction-form/data-correction-form.component";
 import { ContactPageComponent } from "./contact-page/contact-page.component";
 import { MatDialogModule } from "@angular/material/dialog";
 import { SearchPageModule } from "./search-page/search-page.module";
-import { PrivacyPageComponent } from "./privacy-page/privacy-page.component";
-import { DatabaseGuidelinesComponent } from "./database-guidelines/database-guidelines.component";
 import { LoginPageComponent } from "./login-page/login-page.component";
 import { UserNavMenuComponent } from "./user-nav-menu/user-nav-menu.component";
 import { LocalCookiesService } from "./services/authentication/local-cookies.service";
@@ -62,10 +58,6 @@ import { DeleteConfirmationComponent } from "./user-settings-page/delete-confirm
 		SearchBarModule,
 		SearchPageModule,
 		MatDialogModule,
-		PrivacyPageComponent,
-		DatabaseGuidelinesComponent,
-		FaqPageComponent,
-		AboutPageComponent,
 		UserListPageModule,
 		SharedModule
 	],

--- a/src/app/user-profile-page/statistic-display/statistic-display.component.ts
+++ b/src/app/user-profile-page/statistic-display/statistic-display.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from "@angular/core";
+import { Component, Input, OnChanges } from "@angular/core";
 
 @Component({
 	selector: "statistic-display",
@@ -8,9 +8,10 @@ import { Component, Input } from "@angular/core";
 		"[style.width]": "'75%'"
 	}
 })
-export class StatisticDisplayComponent {
+export class StatisticDisplayComponent implements OnChanges {
 	@Input() displayTitle: string;
 	@Input() displayObj: { [key: string]: number };
+	@Input() triggerUpdate: boolean;
 	total = 0;
 
 	ngOnChanges() {

--- a/src/app/user-profile-page/user-profile-page.component.html
+++ b/src/app/user-profile-page/user-profile-page.component.html
@@ -22,9 +22,9 @@
         <div class="profile-content aside-offset">
             <h3 id="#statistics" class="list-display-header">Statistics</h3>
             <div class="list-displays">
-                <statistic-display displayTitle="Activity" [displayObj]="activeStatusCount"></statistic-display>
-                <statistic-display displayTitle="Ownership" [displayObj]="ownershipCount"></statistic-display>
-                <statistic-display displayTitle="Book Type" [displayObj]="bookTypeCount"></statistic-display>
+                <statistic-display displayTitle="Activity" [displayObj]="activeStatusCount" [triggerUpdate]="triggerUpdate"></statistic-display>
+                <statistic-display displayTitle="Ownership" [displayObj]="ownershipCount" [triggerUpdate]="triggerUpdate"></statistic-display>
+                <statistic-display displayTitle="Book Type" [displayObj]="bookTypeCount" [triggerUpdate]="triggerUpdate"></statistic-display>
             </div>
         </div>
     </div>

--- a/src/app/user-profile-page/user-profile-page.component.ts
+++ b/src/app/user-profile-page/user-profile-page.component.ts
@@ -34,7 +34,7 @@ export class UserProfilePageComponent {
 		hardcover: 0,
 		audiobook: 0
 	};
-	finishedInit = false;
+	triggerUpdate = false;
 
 	constructor(
 		private route: ActivatedRoute,
@@ -91,7 +91,7 @@ export class UserProfilePageComponent {
 	}
 
 	refreshComponent() {
-		this.finishedInit = !this.finishedInit;
+		this.triggerUpdate = !this.triggerUpdate;
 	}
 
 	isOnlineText() {


### PR DESCRIPTION
<!-- 
    Thank you for contributing! 
    If you have not already, please review the contribution guidelines before submitting:
    https://github.com/Butterstroke/Myneworm/tree/master/.github/CONTRIBUTING.md
-->

## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Fixed an issue where the profile statistics display was not being displayed on a user's profile.

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

Added an extra input to the statistic displays so that the page can trigger updated when needed. Since the display implements OnChange, the boolean update will cause the display to reload with the appropriate data.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->

Internal#860