### PR TITLE
[Feature/870] Added Timeout To Auto Dismiss Toast Notifications

### DIFF
--- a/src/app/models/toastNotification.ts
+++ b/src/app/models/toastNotification.ts
@@ -1,0 +1,4 @@
+export interface ToastNotification {
+	message: string;
+	status: string;
+}

--- a/src/app/services/toast.service.ts
+++ b/src/app/services/toast.service.ts
@@ -1,12 +1,13 @@
 import { Injectable } from "@angular/core";
 import { BehaviorSubject } from "rxjs";
+import { ToastNotification } from "../models/toastNotification";
 
 @Injectable({
 	providedIn: "root"
 })
 export class ToastService {
-	msgEvent: BehaviorSubject<any> = new BehaviorSubject({});
-	messages: { message: string; status: string }[] = [];
+	msgEvent: BehaviorSubject<ToastNotification[]> = new BehaviorSubject<ToastNotification[]>([]);
+	messages: ToastNotification[] = [];
 
 	constructor() {
 		this.msgEvent.next(this.messages);
@@ -15,6 +16,10 @@ export class ToastService {
 	sendMessage(content: string, status: string) {
 		this.messages.push({ message: content, status: status });
 		this.msgEvent.next(this.messages);
+		setTimeout(
+			() => this.dismissMessage(this.messages.length - 1),
+			Math.max(Math.min(content.length * 50, 2000), 7000)
+		);
 	}
 
 	dismissMessage(msgIndex: number) {

--- a/src/app/shared/toast-messages/toast-messages.component.ts
+++ b/src/app/shared/toast-messages/toast-messages.component.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from "@angular/common";
 import { Component } from "@angular/core";
+import { ToastNotification } from "src/app/models/toastNotification";
 import { ToastService } from "src/app/services/toast.service";
 
 @Component({
@@ -10,7 +11,7 @@ import { ToastService } from "src/app/services/toast.service";
 	standalone: true
 })
 export class ToastMessagesComponent {
-	messages: { message: string; status: string }[];
+	messages: ToastNotification[];
 
 	constructor(private toastService: ToastService) {
 		this.toastService.msgEvent.subscribe((notifications) => {


### PR DESCRIPTION
<!-- 
    Thank you for contributing! 
    If you have not already, please review the contribution guidelines before submitting:
    https://github.com/Butterstroke/Myneworm/tree/master/.github/CONTRIBUTING.md
-->

## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Updates the toast notifications to auto dismiss themselves after a certain period of time instead of needing manual dismissal.

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

Added a setTimeout function to fire after a few seconds depending on message length. At a minimum, the message will be displayed for about 7 seconds.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->

Internal#870