### PR TITLE
[Feature/887] Added Page Buttons to Bottom of Search Page + Lazy Load Images

### DIFF
--- a/src/app/search-page/search-page.component.html
+++ b/src/app/search-page/search-page.component.html
@@ -2,17 +2,16 @@
     <div class="search-div">
         <div class="search-inner-div">
             <form #searchInput="ngForm" (ngSubmit)="submit()" class="search-form">
-                <input type="text" class="search-input-long" placeholder="Search" [(ngModel)]="searchTerm"
-                    #userInput="ngModel" [ngModelOptions]="{standalone: true}"
-                    [ngClass]="{'no-radius-bottom-left' : this.dataSource.data.length > 0 || (this.dataSource.data.length === 0 && this.searchTerm !== '')}" />
-                <button type="submit" class="search-submit-long"
-                    [ngClass]="{'no-radius-bottom-right' : this.dataSource.data.length > 0 || (this.dataSource.data.length === 0 && this.searchTerm !== '')}"
-                    aria-label="Search">
+                <input type="text" class="search-input-long no-radius-bottom-left" placeholder="Search" [(ngModel)]="searchTerm"
+                    #userInput="ngModel" [ngModelOptions]="{standalone: true}" />
+                <button type="submit" class="search-submit-long no-radius-bottom-right" aria-label="Search">
                     <img class="search-btn-icon-long" src="../../assets/fa-search.svg" alt="Search icon" />
                 </button>
             </form>
             <div class="advanced-options-button">
-                <a href="javascript:void(0)" class="clickable-button" (click)="onAdvOptionsClick()">Advanced Options</a>
+                <button class="clickable-button btn myneworm-btn" (click)="onAdvOptionsClick()">
+                    {{ !showAdvancedOptions ? 'Show Filters' : 'Hide Filters' }}
+                </button>
             </div>
         </div>
     </div>
@@ -26,18 +25,16 @@
     <h3 class="search-page-header">Search Results</h3>
     <hr class="search-page-line">
     <div class="search-pagination">
-        <a href="javascript:void(0)" type="button" class="btn myneworm-btn"
-            [ngClass]="this.pageNumber == 1 ? 'no-page' : ''" (click)="prevPage()">
-            < Previous</a>
-                <a href="javascript:void(0)" type="button" class="btn myneworm-btn"
-                    [ngClass]="this.dataSource.filteredData.length === 0 || this.dataSource.filteredData.length < 25 ? 'no-page' : ''"
-                    (click)="nextPage()">Next ></a>
+        <button class="btn myneworm-btn" [ngClass]="this.pageNumber == 1 ? 'no-page' : ''" (click)="prevPage()">&lt; Previous</button>
+        <button class="btn myneworm-btn" 
+            [ngClass]="this.dataSource.filteredData.length === 0 || this.dataSource.filteredData.length < 25 ? 'no-page' : ''"
+            (click)="nextPage()">Next &gt;</button>
     </div>
     <table *ngIf="dataSource" mat-table [dataSource]="dataSource" multiTemplateDataRows class="search-results">
         <ng-container matColumnDef="cover">
             <td class="search-image-row" mat-cell *matCellDef="let element">
-                <a routerLink="/book/{{element.isbn}}"><img class="search-cover-img"
-                        src='{{getCover(element.isbn)}}' alt='Cover for {{element.title}}' /></a>
+                <a routerLink="/book/{{element.isbn}}" [attr.alt]="element.title"><img class="search-cover-img"
+                        src='{{getCover(element.isbn)}}' alt='Cover for {{element.title}}' loading="lazy" /></a>
             </td>
         </ng-container>
         <ng-container matColumnDef="title">
@@ -70,4 +67,10 @@
             </td>
         </tr>
     </table>
+    <div class="search-pagination">
+        <button class="btn myneworm-btn" [ngClass]="this.pageNumber == 1 ? 'no-page' : ''" (click)="prevPage()">&lt; Previous</button>
+        <button class="btn myneworm-btn" 
+            [ngClass]="this.dataSource.filteredData.length === 0 || this.dataSource.filteredData.length < 25 ? 'no-page' : ''"
+            (click)="nextPage()">Next &gt;</button>
+    </div>
 </div>

--- a/src/app/search-page/search-page.component.ts
+++ b/src/app/search-page/search-page.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from "@angular/core";
-import { Location } from "@angular/common";
+import { Location, ViewportScroller } from "@angular/common";
 import { MatTableDataSource } from "@angular/material/table";
 import { ActivatedRoute, Params, Router } from "@angular/router";
 import { BookData } from "../models/bookData";
@@ -25,7 +25,8 @@ export class SearchPageComponent implements OnInit {
 		public utilities: UtilitiesService,
 		private metaService: MetadataService,
 		private router: Router,
-		private location: Location
+		private location: Location,
+		private scroll: ViewportScroller
 	) {
 		this.metaService.updateMetaTags("Search", "/search");
 	}
@@ -49,6 +50,10 @@ export class SearchPageComponent implements OnInit {
 		this.service.searchBooksWithLimit(this.searchTerm, 25, this.pageNumber).subscribe((data: BookData[]) => {
 			this.dataSource = new MatTableDataSource<BookData>(data);
 		});
+	}
+
+	private scrollToTop() {
+		this.scroll.scrollToPosition([0, 0]);
 	}
 
 	submit() {
@@ -76,6 +81,7 @@ export class SearchPageComponent implements OnInit {
 
 		this.location.go(url);
 		this.searchBooks();
+		this.scrollToTop();
 	}
 
 	nextPage() {

--- a/src/app/user-list-page/table-display/table-display.component.html
+++ b/src/app/user-list-page/table-display/table-display.component.html
@@ -5,8 +5,8 @@
             <th mat-header-cell *matHeaderCellDef scope="col" [attr.role]="null"></th>
             <td mat-cell *matCellDef="let element" class="row-padding col-1">
                 <div class="cover-wrapper">
-                    <img class="table-img" src='{{getThumbnail(element.isbn)}}' alt='Cover for {{element.title}}' />
-                    <img class="hover-preview" src='{{getPreview(element.isbn)}}' alt='' />
+                    <img class="table-img" src='{{getThumbnail(element.isbn)}}' alt='Cover for {{element.title}}' loading="lazy" />
+                    <img class="hover-preview" src='{{getPreview(element.isbn)}}' alt='' loading="lazy"/>
                 </div>
             </td>
         </ng-container>


### PR DESCRIPTION
<!-- 
    Thank you for contributing! 
    If you have not already, please review the contribution guidelines before submitting:
    https://github.com/Butterstroke/Myneworm/tree/master/.github/CONTRIBUTING.md
-->

## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Added previous and next page buttons to the bottom of the search results on the search page. They function exactly like the ones on the top of the search results. Updated said buttons from a tags into button tags to help with accessibility and functionality.

Images on the search page and user list pages now have a lazy load flag to allow for some of the images to be loaded later when the user has a chance to see them.

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

Copied the buttons and added a new set after the table element on the HTML file. Then, updated them into buttons and verified they still functioned as anticipated locally. 

For the images, added the flag to the img tag and then verified if the images were lazy loaded in the network tab locally.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->

Internal#887