### PR TITLE
[Feature/892 & Fix/895] Updated User Navigation Menu With Link to User's List + Fixed Mobile Hover Issue

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -19,7 +19,7 @@
                 <li class="nav-li nav-search">
                     <search-bar></search-bar>
                 </li>
-                <li class="nav-li nav-user-menu" *ngIf="isAuthenticated">
+                <li class="nav-li nav-user-menu" *ngIf="isAuthenticated" aria-haspopup="menu">
                     <user-nav-menu></user-nav-menu>
                 </li>
                 <li class="nav-li nav-user-menu" *ngIf="!isAuthenticated">

--- a/src/app/user-nav-menu/user-nav-menu.component.css
+++ b/src/app/user-nav-menu/user-nav-menu.component.css
@@ -8,43 +8,24 @@
     display: none;
 }
 
-.user-menu-wrap:hover > .user-menu {
+.user-menu-wrap:hover > .user-menu,
+.user-menu-wrap:active > .user-menu {
     display: block;
 }
 
 .user-menu {
     z-index: 99;
     position: fixed;
-    background-color: #1F2232;
-    color: #ECEBF3;
-    padding-top: 6px;
-    padding-bottom: 10px;
+    padding: 0;
     width: 200px;
     text-align: center;
     font-size: larger;
+    border-radius: 0 0 8px 8px;
+    overflow-y: hidden;
 }
 
-.user-menu > ul {
-    list-style-type: none;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding-left: 0;
-}
-
-.user-menu > ul > li {
-    width: -webkit-fill-available;
-}
-
-.user-menu-link {
-    color: #ECEBF3;
-    padding-top: 10px;
-    padding-bottom: 10px;
-    text-decoration: none;
+.user-menu > a {
+    padding-top: 14px;
+    padding-bottom: 14px;
     display: block;
-    cursor: pointer;
-}
-
-.user-menu-link:hover {
-    background-color: #0D98BA;
 }

--- a/src/app/user-nav-menu/user-nav-menu.component.html
+++ b/src/app/user-nav-menu/user-nav-menu.component.html
@@ -1,10 +1,9 @@
 <div class="user-menu-wrap">
     <span class="nav-item nav-link nav-user-menu-preview">{{user.username}}</span>
     <div class="user-menu">
-        <ul>
-            <li><a class="user-menu-link" href="/user/{{user.username}}">Profile</a></li>
-            <li><a class="user-menu-link" href="/settings">Settings</a></li>
-            <li><a class="user-menu-link" (click)="logout()">Logout</a></li>
-        </ul>
+        <a class="btn-link btn-div" href="/user/{{user.username}}">Profile</a>
+        <a class="btn-link btn-div" href="/user/{{user.username}}/lists">My List</a>
+        <a class="btn-link btn-div" href="/settings">Settings</a>
+        <a class="myneworm-btn btn-link btn-div" type="button" (click)="logout()">Logout</a>
     </div>
 </div>   

--- a/src/app/user-nav-menu/user-nav-menu.component.ts
+++ b/src/app/user-nav-menu/user-nav-menu.component.ts
@@ -22,7 +22,7 @@ export class UserNavMenuComponent {
 	}
 
 	logout() {
-		this.authService.logout().subscribe((data) => {
+		this.authService.logout().subscribe(() => {
 			this.router.navigate(["/home"]);
 		});
 	}


### PR DESCRIPTION
<!-- 
    Thank you for contributing! 
    If you have not already, please review the contribution guidelines before submitting:
    https://github.com/Butterstroke/Myneworm/tree/master/.github/CONTRIBUTING.md
-->

## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Added an additional link within the user's navigation menu to let the user immediately click to their own list. Also fixed an issue with hovering for the menu as mobile users are unable to hover.

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

Added an additional `a` tag to the list of existing links and verified that it did navigated to the authenticated user's list locally.

Added an additional check for `:active` on the menu wrapper class to allow mobile users to click on their username and bring up the navigation menu.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->

Internal#892 & Internal#895