### PR TITLE
[Feature/753 & Feature/880] Implemented Advanced Filters for Search Page

### DIFF
--- a/src/app/models/BookFormat.ts
+++ b/src/app/models/BookFormat.ts
@@ -1,0 +1,4 @@
+export interface BookFormat {
+	format_name: string;
+	description: string;
+}

--- a/src/app/models/SearchOptions.ts
+++ b/src/app/models/SearchOptions.ts
@@ -1,0 +1,7 @@
+export class SearchOptions {
+	startDate: string | undefined;
+	endDate?: string | undefined;
+	type?: string | undefined;
+	format?: string | undefined;
+	publisher_id?: number | undefined;
+}

--- a/src/app/search-page/search-page.component.css
+++ b/src/app/search-page/search-page.component.css
@@ -16,11 +16,8 @@
     margin-top: 8px;
 }
 
-.advanced-options-button > a {
-    color: #0D98BA;
-}
-
-.hide-adv-options {
+.hide-adv-options,
+.no-page {
     display: none;
 }
 
@@ -92,11 +89,6 @@
     justify-content: flex-end;
 }
 
-.search-pagination > a {
-    margin-right: 10px;
-    color: #0D98BA;
-}
-
 .search-btn-icon-long {
     height: 44px;
 }
@@ -142,10 +134,6 @@
     background-color: #fff;
 }
 
-.no-page {
-    display: none;
-}
-
 .line-clamp {
     display: -webkit-box;
     -webkit-line-clamp: 2;
@@ -173,7 +161,8 @@
     justify-content: flex-end;
 }
 
-.form-buttons > button:nth-child(n + 2) {
+.form-buttons > button:nth-child(n + 2),
+.search-pagination > button:nth-child(n + 2) {
     margin-left: 10px;
 }
 

--- a/src/app/search-page/search-page.component.css
+++ b/src/app/search-page/search-page.component.css
@@ -1,10 +1,3 @@
-.search-page {
-    margin-left: 1%;
-    margin-right: 1%;
-    display: flex;
-    flex-direction: column;
-}
-
 .search-bar-large {
     display: flex;
     flex-direction: row;
@@ -160,8 +153,42 @@
     -webkit-box-orient: vertical;  
 }
 
+.datepicker-decomposed-inputs, .datepicker-decomposed-labels {
+    display: flex;
+    justify-content: space-around;
+}
+
+.advanced-options-form {
+    display: flex;
+    flex-direction: column;
+    width: 50%;
+}
+
+.form-group {
+    margin-bottom: 10px;
+}
+
+.form-buttons {
+    display: inline-flex;
+    justify-content: flex-end;
+}
+
+.form-buttons > button:nth-child(n + 2) {
+    margin-left: 10px;
+}
+
+.advanced-options-form-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
 @media (max-width: 800px) {
     .line-clamp {
         -webkit-line-clamp: 3;
+    }
+
+    .advanced-options-form {
+        width: 100%;
     }
 }

--- a/src/app/search-page/search-page.component.html
+++ b/src/app/search-page/search-page.component.html
@@ -120,8 +120,8 @@
             </select>
         </div>
         <div class="form-buttons">
-            <button class="btn btn-lg myneworm-btn" type="reset" (click)="clearFilters()">Clear Filters</button>
-            <button class="btn btn-lg myneworm-btn" type="submit">Search with Filters</button>
+            <button class="btn myneworm-btn" type="reset" (click)="clearFilters()">Clear Filters</button>
+            <button class="btn myneworm-btn" type="submit">Search with Filters</button>
         </div>
     </form>
     </div>
@@ -165,10 +165,12 @@
             </td>
         </ng-container>
         <tr mat-row *matRowDef="let row; columns: displayedColumns" class="search-result-row"></tr>
-        <tr class="mat-row search-result-row" *matNoDataRow [ngClass]="this.searchTerm !== '' ? '' : 'hide-no-result'">
+        <tr class="mat-row search-result-row" *matNoDataRow [ngClass]="this.searchTerm ? '' : 'hide-no-result'">
             <td class="mat-cell" [attr.colspan]="displayedColumns.length">
                 <strong>
-                    <p class="search-page-message">No results found...</p>
+                    <p class="search-page-message">
+                        No results{{ lastSearchedTerm ? ' found for ' + lastSearchedTerm : '' }}...
+                    </p>
                 </strong>
             </td>
         </tr>

--- a/src/app/search-page/search-page.component.html
+++ b/src/app/search-page/search-page.component.html
@@ -2,14 +2,14 @@
     <div class="search-div">
         <div class="search-inner-div">
             <form #searchInput="ngForm" (ngSubmit)="submit()" class="search-form">
-                <input type="text" class="search-input-long no-radius-bottom-left" placeholder="Search" [(ngModel)]="searchTerm"
-                    #userInput="ngModel" [ngModelOptions]="{standalone: true}" />
+                <input type="text" class="search-input-long no-radius-bottom-left" placeholder="Search"
+                    [(ngModel)]="searchTerm" #userInput="ngModel" [ngModelOptions]="{standalone: true}" />
                 <button type="submit" class="search-submit-long no-radius-bottom-right" aria-label="Search">
                     <img class="search-btn-icon-long" src="../../assets/fa-search.svg" alt="Search icon" />
                 </button>
             </form>
             <div class="advanced-options-button">
-                <button class="clickable-button btn myneworm-btn" (click)="onAdvOptionsClick()">
+                <button class="btn myneworm-btn" (click)="onAdvOptionsClick()">
                     {{ !showAdvancedOptions ? 'Show Filters' : 'Hide Filters' }}
                 </button>
             </div>
@@ -19,14 +19,120 @@
 <div class="advanced-options" [ngClass]="{ 'hide-adv-options': !showAdvancedOptions }">
     <h3 class="search-page-header">Advanced Options</h3>
     <hr class="search-page-line">
-    <p>Coming soon...</p>
+    <div class="advanced-options-form-wrapper">
+    <form #optionsForm="ngForm" class="advanced-options-form" (ngSubmit)="submit()">
+        <div class="form-group">
+            <label for="startDate">
+                <h5>Earliest Date</h5>
+            </label>
+            <br>
+            <small id="startDateHelp" class="form-text text-muted">
+                Inclusive from the date selected: "From or after January 1st, 2022"
+            </small>
+            <div class="datepicker-decomposed-labels">
+                <label for="startYear">
+                    <h6>Year</h6>
+                </label>
+                <label for="startMonth">
+                    <h6>Month</h6>
+                </label>
+                <label for="startDay">
+                    <h6>Day</h6>
+                </label>
+            </div>
+            <div class="datepicker-decomposed-inputs">
+                <input type="number" class="form-control" name="startYear" id="startYear" [(ngModel)]="startDate.year" (input)="onStartDateChange()">
+                <select class="form-select" name="startMonth" id="startMonth" [(ngModel)]="startDate.month" (ngModelChange)="onStartDateChange()"
+                    [disabled]="startDate.year === null || startDate.year === ''">
+                    <option value=""></option>
+                    <option *ngFor="let item of [].constructor(12); let i = index" [ngValue]="i">
+                        {{getMonth(i)}}
+                    </option>
+                </select>
+                <input type="number" class="form-control" name="startDay" id="startDay" [(ngModel)]="startDate.day" (input)="onStartDateChange()"
+                    [disabled]="startDate.month === null || startDate.month === ''">
+            </div>
+        </div>
+        <div class="form-group">
+            <label for="endDate">
+                <h5>Latest Date</h5>
+            </label>
+            <br>
+            <small id="endDateHelp" class="form-text text-muted">
+                Inclusive from the date selected: "Before or on January 1st, 2022"
+            </small>
+            <div class="datepicker-decomposed-labels">
+                <label for="endYear">
+                    <h6>Year</h6>
+                </label>
+                <label for="endMonth">
+                    <h6>Month</h6>
+                </label>
+                <label for="endDay">
+                    <h6>Day</h6>
+                </label>
+            </div>
+            <div class="datepicker-decomposed-inputs">
+                <input type="number" class="form-control" name="endYear" id="endYear" [(ngModel)]="endDate.year" (input)="onEndDateChange()">
+                <select class="form-select" name="endMonth" id="endMonth" [(ngModel)]="endDate.month" (ngModelChange)="onEndDateChange()"
+                    [disabled]="endDate.year === null || endDate.year === ''">
+                    <option value=""></option>
+                    <option *ngFor="let item of [].constructor(12); let i = index" [ngValue]="i">
+                        {{getMonth(i)}}
+                    </option>
+                </select>
+                <input type="number" class="form-control" name="endDay" id="endDay" [(ngModel)]="endDate.day" (input)="onEndDateChange()"
+                    [disabled]="endDate.month === null || endDate.month === ''">
+            </div>
+        </div>
+        <div class="form-group">
+            <label for="publisher_id">
+                <h5>Imprint</h5>
+            </label>
+            <select class="form-select" name="publisher_id" id="publisher_id"
+                [(ngModel)]="advancedOptions.publisher_id">
+                <option value=""></option>
+                <option *ngFor="let publisher of publishers" [ngValue]="publisher.publisher_id">
+                    {{publisher.name}}
+                </option>
+            </select>
+        </div>
+        <div class="form-group">
+            <label for="format">
+                <h5>Format</h5>
+            </label>
+            <select class="form-select" name="format" id="format" [(ngModel)]="advancedOptions.format">
+                <option value=""></option>
+                <option *ngFor="let format of formats" [ngValue]="format.format_name">
+                    {{this.utilities.formatReadable(format.format_name)}}
+                </option>
+            </select>
+        </div>
+        <div class="form-group">
+            <label for="type">
+                <h5>Type</h5>
+            </label>
+            <select class="form-select" name="type" id="type" [(ngModel)]="advancedOptions.type">
+                <option value=""></option>
+                <option *ngFor="let type of types" [ngValue]="type.book_type_name">
+                    {{this.utilities.toTitleCase(type.book_type_name)}}
+                </option>
+            </select>
+        </div>
+        <div class="form-buttons">
+            <button class="btn btn-lg myneworm-btn" type="reset" (click)="clearFilters()">Clear Filters</button>
+            <button class="btn btn-lg myneworm-btn" type="submit">Search with Filters</button>
+        </div>
+    </form>
+    </div>
 </div>
 <div class="search-results">
     <h3 class="search-page-header">Search Results</h3>
     <hr class="search-page-line">
     <div class="search-pagination">
-        <button class="btn myneworm-btn" [ngClass]="this.pageNumber == 1 ? 'no-page' : ''" (click)="prevPage()">&lt; Previous</button>
-        <button class="btn myneworm-btn" 
+        <button class="btn myneworm-btn" [ngClass]="this.pageNumber == 1 ? 'no-page' : ''" (click)="prevPage()">&lt;
+            Previous</button>
+        <button class="btn myneworm-btn"
             [ngClass]="this.dataSource.filteredData.length === 0 || this.dataSource.filteredData.length < 25 ? 'no-page' : ''"
             (click)="nextPage()">Next &gt;</button>
     </div>
@@ -68,8 +174,9 @@
         </tr>
     </table>
     <div class="search-pagination">
-        <button class="btn myneworm-btn" [ngClass]="this.pageNumber == 1 ? 'no-page' : ''" (click)="prevPage()">&lt; Previous</button>
-        <button class="btn myneworm-btn" 
+        <button class="btn myneworm-btn" [ngClass]="this.pageNumber == 1 ? 'no-page' : ''" (click)="prevPage()">&lt;
+            Previous</button>
+        <button class="btn myneworm-btn"
             [ngClass]="this.dataSource.filteredData.length === 0 || this.dataSource.filteredData.length < 25 ? 'no-page' : ''"
             (click)="nextPage()">Next &gt;</button>
     </div>

--- a/src/app/search-page/search-page.component.html
+++ b/src/app/search-page/search-page.component.html
@@ -43,14 +43,14 @@
             <div class="datepicker-decomposed-inputs">
                 <input type="number" class="form-control" name="startYear" id="startYear" [(ngModel)]="startDate.year" (input)="onStartDateChange()">
                 <select class="form-select" name="startMonth" id="startMonth" [(ngModel)]="startDate.month" (ngModelChange)="onStartDateChange()"
-                    [disabled]="startDate.year === null || startDate.year === ''">
-                    <option value=""></option>
+                    [disabled]="startDate.year === null">
+                    <option value="-1"></option>
                     <option *ngFor="let item of [].constructor(12); let i = index" [ngValue]="i">
                         {{getMonth(i)}}
                     </option>
                 </select>
                 <input type="number" class="form-control" name="startDay" id="startDay" [(ngModel)]="startDate.day" (input)="onStartDateChange()"
-                    [disabled]="startDate.month === null || startDate.month === ''">
+                    [disabled]="startDate.month === null || startDate.month === -1">
             </div>
         </div>
         <div class="form-group">
@@ -75,14 +75,14 @@
             <div class="datepicker-decomposed-inputs">
                 <input type="number" class="form-control" name="endYear" id="endYear" [(ngModel)]="endDate.year" (input)="onEndDateChange()">
                 <select class="form-select" name="endMonth" id="endMonth" [(ngModel)]="endDate.month" (ngModelChange)="onEndDateChange()"
-                    [disabled]="endDate.year === null || endDate.year === ''">
-                    <option value=""></option>
+                    [disabled]="endDate.year === null">
+                    <option value="-1"></option>
                     <option *ngFor="let item of [].constructor(12); let i = index" [ngValue]="i">
                         {{getMonth(i)}}
                     </option>
                 </select>
                 <input type="number" class="form-control" name="endDay" id="endDay" [(ngModel)]="endDate.day" (input)="onEndDateChange()"
-                    [disabled]="endDate.month === null || endDate.month === ''">
+                    [disabled]="endDate.month === null || endDate.month === -1">
             </div>
         </div>
         <div class="form-group">

--- a/src/app/search-page/search-page.component.ts
+++ b/src/app/search-page/search-page.component.ts
@@ -6,6 +6,12 @@ import { BookData } from "../models/bookData";
 import { MetadataService } from "../services/metadata.service";
 import { MynewormAPIService } from "../services/myneworm-api.service";
 import { UtilitiesService } from "../services/utilities.service";
+import { SearchOptions } from "../models/SearchOptions";
+import { BookType } from "../models/BookType";
+import { BookFormat } from "../models/BookFormat";
+import { ImprintData } from "../models/imprintData";
+import * as moment from "moment";
+import { ToastService } from "../services/toast.service";
 
 @Component({
 	selector: "search-page",
@@ -18,6 +24,20 @@ export class SearchPageComponent implements OnInit {
 	public dataSource: MatTableDataSource<BookData> = new MatTableDataSource<BookData>();
 	showAdvancedOptions = false;
 	pageNumber = 1;
+	advancedOptions = new SearchOptions();
+	types: BookType[];
+	formats: BookFormat[];
+	publishers: ImprintData[];
+	startDate = {
+		year: null,
+		month: null,
+		day: null
+	};
+	endDate = {
+		year: null,
+		month: null,
+		day: null
+	};
 
 	constructor(
 		private route: ActivatedRoute,
@@ -26,7 +46,8 @@ export class SearchPageComponent implements OnInit {
 		private metaService: MetadataService,
 		private router: Router,
 		private location: Location,
-		private scroll: ViewportScroller
+		private scroll: ViewportScroller,
+		private toastService: ToastService
 	) {
 		this.metaService.updateMetaTags("Search", "/search");
 	}
@@ -39,21 +60,129 @@ export class SearchPageComponent implements OnInit {
 
 			this.searchTerm = params.term;
 			this.pageNumber = params.page || 1;
-			this.searchBooks();
+			this.advancedOptions.startDate = params.start;
+			this.advancedOptions.endDate = params.end;
+			this.advancedOptions.type = params.type;
+			this.advancedOptions.format = params.format;
+			this.advancedOptions.publisher_id = params.publisher;
+
+			if (params.start || params.end || params.type || params.format || params.publisher) {
+				this.showAdvancedOptions = true;
+			}
+
+			this.searchBooks(this.generateParams());
+		});
+
+		this.service.getBookTypes().subscribe((data) => this.types = data);
+		this.service.getBookFormats().subscribe((data) => this.formats = data);
+		this.service.getImprints().subscribe((data) => {
+			this.publishers = data;
+			if (this.advancedOptions.publisher_id) {
+				this.advancedOptions.publisher_id++;
+				this.advancedOptions.publisher_id--;
+			}
 		});
 	}
 
-	private searchBooks() {
-		if (this.searchTerm === "") {
+	private searchBooks(queryParams: Params) {
+		if (Object.keys(queryParams).length < 3) {
+			// Params only are page and limit counts
+			this.toastService.sendError("No parameters provided. Unable to search");
 			return;
 		}
-		this.service.searchBooksWithLimit(this.searchTerm, 25, this.pageNumber).subscribe((data: BookData[]) => {
+
+		this.service.searchBooksWithFilter(queryParams).subscribe((data: BookData[]) => {
 			this.dataSource = new MatTableDataSource<BookData>(data);
 		});
 	}
 
 	private scrollToTop() {
 		this.scroll.scrollToPosition([0, 0]);
+	}
+
+	private generateParams(): Params {
+		const queryParams: Params = {
+			page: this.pageNumber,
+			limit: 25
+		};
+
+		if (this.searchTerm) {
+			queryParams["term"] = this.searchTerm;
+		}
+
+		if (this.showAdvancedOptions) {
+			if (this.advancedOptions.startDate) {
+				queryParams["start"] = this.advancedOptions.startDate;
+			}
+			if (this.advancedOptions.endDate) {
+				queryParams["end"] = this.advancedOptions.endDate;
+			}
+			if (this.advancedOptions.publisher_id) {
+				queryParams["publisher"] = this.advancedOptions.publisher_id;
+			}
+			if (this.advancedOptions.type) {
+				queryParams["type"] = this.advancedOptions.type;
+			}
+			if (this.advancedOptions.format) {
+				queryParams["format"] = this.advancedOptions.format;
+			}
+		}
+
+		return queryParams;
+	}
+
+	clearFilters() {
+		this.advancedOptions = new SearchOptions();
+	}
+
+	onStartDateChange() {
+		if (this.startDate.year === null) {
+			this.advancedOptions.startDate = undefined;
+			this.startDate.month = null;
+			this.startDate.day = null;
+			return;
+		}
+
+		const targetDate = moment().startOf("year").set("year", this.startDate.year);
+
+		if (this.startDate.month !== null && this.startDate.month !== "") {
+			targetDate.set("month", this.startDate.month);
+		} else {
+			this.startDate.day = null;
+		}
+
+		if (this.startDate.day !== null) {
+			targetDate.set("date", this.startDate.day);
+		}
+
+		this.advancedOptions.startDate = targetDate.format("YYYY-MM-DD");
+	}
+
+	onEndDateChange() {
+		if (this.endDate.year === null) {
+			this.advancedOptions.endDate = undefined;
+			this.endDate.month = null;
+			this.endDate.day = null;
+			return;
+		}
+
+		const targetDate = moment().startOf("year").set("year", this.endDate.year);
+
+		if (this.endDate.month !== null && this.endDate.month !== "") {
+			targetDate.set("month", this.endDate.month);
+		} else {
+			this.endDate.day = null;
+		}
+
+		if (this.endDate.day !== null) {
+			targetDate.set("date", this.endDate.day);
+		}
+
+		this.advancedOptions.endDate = targetDate.format("YYYY-MM-DD");
+	}
+
+	getMonth(i: number) {
+		return new Date(0, i).toLocaleString("en", { month: "long" });
 	}
 
 	submit() {
@@ -66,21 +195,18 @@ export class SearchPageComponent implements OnInit {
 	}
 
 	updateQuery() {
-		const queryParams: Params = {
-			term: this.searchTerm,
-			page: this.pageNumber
-		};
+		const params = this.generateParams();
 
 		const url = this.router
 			.createUrlTree([], {
 				relativeTo: this.route,
-				queryParams: queryParams,
+				queryParams: params,
 				queryParamsHandling: "merge"
 			})
 			.toString();
 
 		this.location.go(url);
-		this.searchBooks();
+		this.searchBooks(params);
 		this.scrollToTop();
 	}
 

--- a/src/app/search-page/search-page.component.ts
+++ b/src/app/search-page/search-page.component.ts
@@ -28,12 +28,12 @@ export class SearchPageComponent implements OnInit {
 	types: BookType[];
 	formats: BookFormat[];
 	publishers: ImprintData[];
-	startDate = {
+	startDate: { [key: string]: number | null } = {
 		year: null,
 		month: null,
 		day: null
 	};
-	endDate = {
+	endDate: { [key: string]: number | null } = {
 		year: null,
 		month: null,
 		day: null
@@ -68,6 +68,20 @@ export class SearchPageComponent implements OnInit {
 
 			if (params.start || params.end || params.type || params.format || params.publisher) {
 				this.showAdvancedOptions = true;
+			}
+
+			if (params.start) {
+				const date = moment(params.start);
+				this.startDate.year = date.get("year");
+				this.startDate.month = date.get("month");
+				this.startDate.day = date.get("date");
+			}
+
+			if (params.end) {
+				const date = moment(params.end);
+				this.endDate.year = date.get("year");
+				this.endDate.month = date.get("month");
+				this.endDate.day = date.get("date");
 			}
 
 			this.searchBooks(this.generateParams());
@@ -157,7 +171,7 @@ export class SearchPageComponent implements OnInit {
 
 		const targetDate = moment().startOf("year").set("year", this.startDate.year);
 
-		if (this.startDate.month !== null && this.startDate.month !== "") {
+		if (this.startDate.month !== null && this.startDate.month !== -1) {
 			targetDate.set("month", this.startDate.month);
 		} else {
 			this.startDate.day = null;
@@ -180,7 +194,7 @@ export class SearchPageComponent implements OnInit {
 
 		const targetDate = moment().startOf("year").set("year", this.endDate.year);
 
-		if (this.endDate.month !== null && this.endDate.month !== "") {
+		if (this.endDate.month !== null && this.endDate.month !== -1) {
 			targetDate.set("month", this.endDate.month);
 		} else {
 			this.endDate.day = null;

--- a/src/app/services/myneworm-api.service.ts
+++ b/src/app/services/myneworm-api.service.ts
@@ -13,6 +13,7 @@ import { RegistrationData } from "../models/RegistrationData";
 import { ProfileUpdateData } from "../models/profileUpdateData";
 import { AccountUpdateData } from "../models/accountUpdateData";
 import { AssetSize } from "../models/AssetSize";
+import { BookFormat } from "../models/BookFormat";
 
 @Injectable({
 	providedIn: "root"
@@ -109,6 +110,10 @@ export class MynewormAPIService {
 
 	getBookTypes() {
 		return this.http.get<BookType[]>(`${environment.API_ADDRESS}/booktype`);
+	}
+
+	getBookFormats() {
+		return this.http.get<BookFormat[]>(`${environment.API_ADDRESS}/bookformat`);
 	}
 
 	getAuthUser(userID: string) {

--- a/src/app/services/myneworm-api.service.ts
+++ b/src/app/services/myneworm-api.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from "@angular/core";
 import { environment } from "src/environments/environment";
-import { HttpClient } from "@angular/common/http";
+import { HttpClient, HttpParams } from "@angular/common/http";
 import { ImprintData } from "../models/imprintData";
 import { MonthReleaseData } from "../models/monthReleaseData";
 import { BookData } from "../models/bookData";
@@ -14,6 +14,7 @@ import { ProfileUpdateData } from "../models/profileUpdateData";
 import { AccountUpdateData } from "../models/accountUpdateData";
 import { AssetSize } from "../models/AssetSize";
 import { BookFormat } from "../models/BookFormat";
+import { Params } from "@angular/router";
 
 @Injectable({
 	providedIn: "root"
@@ -78,6 +79,14 @@ export class MynewormAPIService {
 		}
 
 		return this.http.get<BookData[]>(`${environment.API_ADDRESS}/book/search/${page}?term=${term}&limit=${limit}`);
+	}
+
+	searchBooksWithFilter(queryParams: Params) {
+		return this.http.get<BookData[]>(
+			`${environment.API_ADDRESS}/book/search/${queryParams["page"]}?${new HttpParams({
+				fromObject: queryParams
+			}).toString()}`
+		);
 	}
 
 	searchBooks(publisherID?: string, startDate?: string, endDate?: string) {


### PR DESCRIPTION
<!-- 
    Thank you for contributing! 
    If you have not already, please review the contribution guidelines before submitting:
    https://github.com/Butterstroke/Myneworm/tree/master/.github/CONTRIBUTING.md
-->

## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Implements the advanced filters options on the search page as well as add indicators if the result table used a term to search with.

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

Created a new form that appears when the user clicks on the "Show filters" button. On click, the form appears and the user is able to enter in earliest date, latest date, imprint, book type, and book format to filter the search further. 

If the user uses a link with parameters in it, the page will automatically input those values into the filter form and search based on what was defined. The form will also be present when the user loads the page for the first time.

Also update the "No Results" message to include the term it used to search as well as if filters were present in the result.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->

Internal#753 & Internal#880