### PR TITLE
[Fix/889] Updated ListEntryModal to Allow for Null Values on Dates

### DIFF
--- a/src/app/models/ListEntry.ts
+++ b/src/app/models/ListEntry.ts
@@ -3,8 +3,8 @@ export interface ListEntry {
 	user_id: number;
 	isbn: number;
 	title: string;
-	start_date?: string;
-	end_date?: string;
+	start_date?: string | null;
+	end_date?: string | null;
 	book_type_name: string;
 	score: number;
 	reread: number;
@@ -19,8 +19,8 @@ export class ListEntryClass implements ListEntry {
 	user_id: number;
 	isbn: number;
 	title: string;
-	start_date?: string;
-	end_date?: string;
+	start_date?: string | null;
+	end_date?: string | null;
 	book_type_name: string;
 	score: number;
 	reread: number;

--- a/src/app/shared/list-entry-modal/list-entry-modal.component.ts
+++ b/src/app/shared/list-entry-modal/list-entry-modal.component.ts
@@ -78,13 +78,16 @@ export class ListEntryModalComponent {
 
 	validateDate(start: boolean) {
 		const dateToCheck = start ? this.listEntryForm.start_date : this.listEntryForm.end_date;
-		if (dateToCheck === undefined || dateToCheck === "") {
-			return;
-		}
 
-		if (isNaN(new Date(dateToCheck).getTime())) {
+		if (dateToCheck && isNaN(new Date(dateToCheck).getTime())) {
 			this.toastService.sendError("Unable to parse date input. One or more date values exceed date range.");
 			return;
+		} else if (dateToCheck) {
+			if (start) {
+				this.listEntryForm.start_date = this.utilities.APIDateFormatter(new Date(dateToCheck));
+			} else {
+				this.listEntryForm.end_date = this.utilities.APIDateFormatter(new Date(dateToCheck));
+			}
 		}
 	}
 
@@ -140,6 +143,13 @@ export class ListEntryModalComponent {
 		if (!Object.values(this.activityStatus).includes(this.listEntryForm.active_status)) {
 			this.toastService.sendError("Activity status is required to add a list entry.");
 			return;
+		}
+
+		if (this.listEntryForm.start_date === "") {
+			this.listEntryForm.start_date = null;
+		}
+		if (this.listEntryForm.end_date === "") {
+			this.listEntryForm.end_date = null;
 		}
 
 		if (this.isUpdate) {


### PR DESCRIPTION
<!-- 
    Thank you for contributing! 
    If you have not already, please review the contribution guidelines before submitting:
    https://github.com/Butterstroke/Myneworm/tree/master/.github/CONTRIBUTING.md
-->

## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Updates the datepickers in the ListEntryModal to allow for null/undefined values submitted by the user.

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

Prevents overwrite by backend functions if the date becomes "". Then, on submission, a final check is made and any "" or undefined value is overwritten to null on entry update.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->

Internal#889