### PR TITLE
[Spike/903] Encoded Password Before Sending to API to Update Account Details

### DIFF
--- a/src/app/services/myneworm-api.service.ts
+++ b/src/app/services/myneworm-api.service.ts
@@ -154,6 +154,10 @@ export class MynewormAPIService {
 	}
 
 	updateAccount(accountInfo: AccountUpdateData) {
+		if (accountInfo.password) {
+			accountInfo.password = Buffer.from(accountInfo.password).toString("base64");
+		}
+
 		return this.http.patch(`${environment.API_ADDRESS}/user`, { user: accountInfo });
 	}
 


### PR DESCRIPTION
<!-- 
    Thank you for contributing! 
    If you have not already, please review the contribution guidelines before submitting:
    https://github.com/Butterstroke/Myneworm/tree/master/.github/CONTRIBUTING.md
-->

## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Patches the updateAccount function for the Myneworm-API to encode the password before sending it to the API.

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

Encoded using Base64 as the service already does for login credentials.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->

Internal#903