### PR TITLE
[Fix/863, Feature/879, & Fix/905] Added Ordered Status + Updated List Page

### DIFF
--- a/src/app/functions/formatOwnerStatus.ts
+++ b/src/app/functions/formatOwnerStatus.ts
@@ -14,5 +14,8 @@ export function formatOwnerStatus(status: string): string {
 	if (status === "wanting") {
 		return "Wanted";
 	}
+	if (status === "ordered") {
+		return "Ordered";
+	}
 	return "Failed to translate status";
 }

--- a/src/app/models/ListEntryStatus.ts
+++ b/src/app/models/ListEntryStatus.ts
@@ -10,5 +10,6 @@ export const OwnershipStatus = {
 	Wanted: "wanting",
 	Loaned: "loaned",
 	"Previously Owned": "previous_own",
-	Owned: "owned"
+	Owned: "owned",
+	Ordered: "ordered"
 };

--- a/src/app/models/userStatisticsData.ts
+++ b/src/app/models/userStatisticsData.ts
@@ -9,6 +9,7 @@ export interface UserStatisticsProfile {
 	owner_loaned: number;
 	owner_previous: number;
 	owner_owned: number;
+	owner_ordered: number;
 	type_paperback: number;
 	type_ebook: number;
 	type_hardcover: number;

--- a/src/app/user-list-page/table-display/table-display.component.css
+++ b/src/app/user-list-page/table-display/table-display.component.css
@@ -24,6 +24,10 @@ tr {
     color: #1F2232;
 }
 
+.entry-row {
+    height: 87px;
+}
+
 ::ng-deep .mat-sort-header-container {
     justify-content: center;
 }

--- a/src/app/user-list-page/table-display/table-display.component.html
+++ b/src/app/user-list-page/table-display/table-display.component.html
@@ -1,6 +1,7 @@
 <div *ngIf="listEntries.filteredData.length > 0">
     <h3>{{tableName}}</h3>
-    <table mat-table matSort [dataSource]="listEntries" multiTemplateDataRows matSort>
+    <table mat-table matSort [dataSource]="listEntries" multiTemplateDataRows matSort
+        matSortActive="title" matSortDirection="asc" matSortDisableClear>
         <ng-container matColumnDef="cover">
             <th mat-header-cell *matHeaderCellDef scope="col" [attr.role]="null"></th>
             <td mat-cell *matCellDef="let element" class="row-padding col-1">

--- a/src/app/user-list-page/table-display/table-display.component.html
+++ b/src/app/user-list-page/table-display/table-display.component.html
@@ -1,11 +1,11 @@
-<div *ngIf="listEntries.length > 0">
+<div *ngIf="listEntries.filteredData.length > 0">
     <h3>{{tableName}}</h3>
-    <table mat-table matSort [dataSource]="listEntries" multiTemplateDataRows (matSortChange)="sortData($event)">
+    <table mat-table matSort [dataSource]="listEntries" multiTemplateDataRows matSort>
         <ng-container matColumnDef="cover">
             <th mat-header-cell *matHeaderCellDef scope="col" [attr.role]="null"></th>
             <td mat-cell *matCellDef="let element" class="row-padding col-1">
                 <div class="cover-wrapper">
-                    <img class="table-img" src='{{getThumbnail(element.isbn)}}' alt='Cover for {{element.title}}' loading="lazy" />
+                    <img class="table-img" src='{{getPreview(element.isbn)}}' alt='Cover for {{element.title}}' loading="lazy" />
                     <img class="hover-preview" src='{{getPreview(element.isbn)}}' alt='' loading="lazy"/>
                 </div>
             </td>
@@ -22,7 +22,6 @@
                 class="align-center">Score</th>
             <td mat-cell *matCellDef="let element" class="align-center col-1">
                 <span *ngIf="element.score > 0">{{element.score}}</span>
-                <span *ngIf="element.score === 0">-</span>
             </td>
         </ng-container>
         <ng-container matColumnDef="reread">
@@ -30,7 +29,6 @@
                 class="align-center">Reread</th>
             <td mat-cell *matCellDef="let element" class="align-center col-1">
                 <span *ngIf="element.reread > 0">{{element.reread}}</span>
-                <span *ngIf="element.reread === 0">-</span>
             </td>
         </ng-container>
         <ng-container matColumnDef="owner">
@@ -73,7 +71,7 @@
             </td>
         </ng-container>
         <tr mat-header-row *matHeaderRowDef="displayedColumns" [attr.role]="null"></tr>
-        <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns" class="entry-row"></tr>
         <tr mat-row *matRowDef="let row; columns: ['expandedDetail']"
             [ngClass]="row.isExpanded ? 'expanded' : 'collapsed'"></tr>
     </table>

--- a/src/app/user-list-page/user-list-page.component.html
+++ b/src/app/user-list-page/user-list-page.component.html
@@ -29,6 +29,11 @@
         <div class="list-filter-div">
             <h4>Ownership</h4>
             <div class="form-check">
+                <input type="checkbox" id="ordered" value="ordered" class="form-check-input" 
+                    [checked]='this.ownershipFilter.includes("ordered")' (click)="addOwnership('ordered')">
+                <label for="ordered" class="form-check-label">Ordered</label>
+            </div>
+            <div class="form-check">
                 <input type="checkbox" id="owned" value="owned" class="form-check-input" 
                     [checked]='this.ownershipFilter.includes("owned")' (click)="addOwnership('owned')">
                 <label for="owned" class="form-check-label">Owned</label>
@@ -78,15 +83,15 @@
     </aside>
     <main class="col-9" *ngIf="isLoading === false">
         <table-display *ngIf="appliedFilter === 0 || (filter.reading && appliedFilter > 0)" [triggerListUpdate]="triggerListUpdate"
-            [_allEntries]="readingSource" tableName="Reading" [ownershipFilter]="ownershipFilter" [booktypeFilter]="booktypeFilter" [isAuthUser]="isAuthUser"></table-display>
+            [listEntries]="readingSource" tableName="Reading" [ownershipFilter]="ownershipFilter" [booktypeFilter]="booktypeFilter" [isAuthUser]="isAuthUser"></table-display>
         <table-display *ngIf="appliedFilter === 0 || (filter.completed && appliedFilter > 0)" [triggerListUpdate]="triggerListUpdate"
-            [_allEntries]="completedSource" tableName="Completed" [ownershipFilter]="ownershipFilter" [booktypeFilter]="booktypeFilter" [isAuthUser]="isAuthUser"></table-display>
+            [listEntries]="completedSource" tableName="Completed" [ownershipFilter]="ownershipFilter" [booktypeFilter]="booktypeFilter" [isAuthUser]="isAuthUser"></table-display>
         <table-display *ngIf="appliedFilter === 0 || (filter.paused && appliedFilter > 0)" [triggerListUpdate]="triggerListUpdate"
-            [_allEntries]="pausedSource" tableName="Paused" [ownershipFilter]="ownershipFilter" [booktypeFilter]="booktypeFilter" [isAuthUser]="isAuthUser"></table-display>
+            [listEntries]="pausedSource" tableName="Paused" [ownershipFilter]="ownershipFilter" [booktypeFilter]="booktypeFilter" [isAuthUser]="isAuthUser"></table-display>
         <table-display *ngIf="appliedFilter === 0 || (filter.dropped && appliedFilter > 0)" [triggerListUpdate]="triggerListUpdate"
-            [_allEntries]="droppedSource" tableName="Dropped" [ownershipFilter]="ownershipFilter" [booktypeFilter]="booktypeFilter" [isAuthUser]="isAuthUser"></table-display>
+            [listEntries]="droppedSource" tableName="Dropped" [ownershipFilter]="ownershipFilter" [booktypeFilter]="booktypeFilter" [isAuthUser]="isAuthUser"></table-display>
         <table-display *ngIf="appliedFilter === 0 || (filter.planning && appliedFilter > 0)" [triggerListUpdate]="triggerListUpdate"
-            [_allEntries]="planningSource" tableName="Planning" [ownershipFilter]="ownershipFilter" [booktypeFilter]="booktypeFilter" [isAuthUser]="isAuthUser"></table-display>
+            [listEntries]="planningSource" tableName="Planning" [ownershipFilter]="ownershipFilter" [booktypeFilter]="booktypeFilter" [isAuthUser]="isAuthUser"></table-display>
         <div *ngIf="hasEntries === false">
             <p><b>User does not have any books in their list.</b></p>
             <a class="aside-link" href="/user/{{listUser}}">Return to {{listUser}}'s profile</a>

--- a/src/app/user-list-page/user-list-page.component.ts
+++ b/src/app/user-list-page/user-list-page.component.ts
@@ -80,33 +80,24 @@ export class UserListPageComponent {
 	}
 
 	compileLists(listEntries: ListEntry[]) {
-		const lists: { [key: string]: ListEntry[] } = {};
-
 		for (const entry of listEntries) {
 			entry["isExpanded"] = false;
-			if (Object.prototype.hasOwnProperty.call(lists, entry.active_status)) {
-				lists[entry.active_status].push(entry);
-			} else {
-				lists[entry.active_status] = [entry];
-			}
-		}
 
-		for (const key of Object.keys(lists)) {
-			switch (key) {
+			switch (entry.active_status) {
 				case "reading":
-					this.readingSource.data = lists[key];
+					this.readingSource.data.push(entry);
 					break;
 				case "completed":
-					this.completedSource.data = lists[key];
+					this.completedSource.data.push(entry);
 					break;
 				case "paused":
-					this.pausedSource.data = lists[key];
+					this.pausedSource.data.push(entry);
 					break;
 				case "dropped":
-					this.droppedSource.data = lists[key];
+					this.droppedSource.data.push(entry);
 					break;
 				case "planning":
-					this.planningSource.data = lists[key];
+					this.planningSource.data.push(entry);
 					break;
 				default:
 					throw new Error("Type not in switch for table data");

--- a/src/app/user-profile-page/statistic-display/statistic-display.component.css
+++ b/src/app/user-profile-page/statistic-display/statistic-display.component.css
@@ -10,7 +10,7 @@
     overflow: hidden;
 }
 
-.reading, .ebook {
+.reading, .ordered, .ebook {
     background-color: blue;
 }
 

--- a/src/app/user-profile-page/user-profile-page.component.ts
+++ b/src/app/user-profile-page/user-profile-page.component.ts
@@ -26,7 +26,8 @@ export class UserProfilePageComponent {
 		owned: 0,
 		previous_own: 0,
 		loaned: 0,
-		wanted: 0
+		wanted: 0,
+		ordered: 0
 	};
 	bookTypeCount = {
 		paperback: 0,
@@ -79,6 +80,7 @@ export class UserProfilePageComponent {
 					this.ownershipCount.loaned = data.owner_loaned;
 					this.ownershipCount.previous_own = data.owner_previous;
 					this.ownershipCount.wanted = data.owner_wanting;
+					this.ownershipCount.ordered = data.owner_ordered;
 
 					this.bookTypeCount.paperback = data.type_paperback;
 					this.bookTypeCount.ebook = data.type_ebook;


### PR DESCRIPTION
<!-- 
    Thank you for contributing! 
    If you have not already, please review the contribution guidelines before submitting:
    https://github.com/Butterstroke/Myneworm/tree/master/.github/CONTRIBUTING.md
-->

## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Added `Ordered` ownership status across the site as needed. Also fixed two issues with the user list page and sorting. First, tables are now sorted by titles in ascending order. Second, fixed an issue with sort options not rearranging the entries. 

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

For the ordered status, updated various enums and conditions around the site where other ownership statuses were used.

For the list page, unified everything in an Angular MatTableDataSource element. Then updated the variable with a custom filter and sort function to handle conditions on the page. Likewise, added various MatSort options into the table display which reenabled various sort mechanics.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->

Internal#863, Internal#879, & Internal#905