### PR TITLE
[Fix/931] Fixed Navigation Search Results Not Being Overlaid On Top of Content

### DIFF
--- a/src/app/shared/navigation-bar.css
+++ b/src/app/shared/navigation-bar.css
@@ -13,6 +13,7 @@
     padding-top: 0;
     padding-bottom: 0;
     overflow: hidden;
+    position: inherit;
 }
 
 .nav-list-ul {


### PR DESCRIPTION
<!-- 
    Thank you for contributing! 
    If you have not already, please review the contribution guidelines before submitting:
    https://github.com/Butterstroke/Myneworm/tree/master/.github/CONTRIBUTING.md
-->

## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Fixes an issue where the navigation search bar results would hide behind site content and not overlaid on top of the content as intended.

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

Added a position rule in the CSS file as apart of `nav-list`.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->

Internal#931