### PR TITLE
[Fix/934] Fixed Style Issue Where Footer Contact Link Would Change Colour on Hover

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -31,7 +31,7 @@ body {
  */
 .button-link, .button-link:visited,
 .btn-link, .btn-link:visited {
-    color: #ECEBF3;
+    color: #ECEBF3 !important;
     text-decoration: none;
 }
 


### PR DESCRIPTION
<!-- 
    Thank you for contributing! 
    If you have not already, please review the contribution guidelines before submitting:
    https://github.com/Butterstroke/Myneworm/tree/master/.github/CONTRIBUTING.md
-->

## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Fixes a CSS style issue where not all of the btn-link classed links kept their colour on hover.

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

Added `!important` to the style property.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->

Internal#934