### PR TITLE
[Feature/938] Create Page for Book Corrections in Admin Panel

### DIFF
--- a/src/app/admin-pages/admin-routing.module.ts
+++ b/src/app/admin-pages/admin-routing.module.ts
@@ -21,7 +21,7 @@ const routes: Routes = [
 				path: "corrections",
 				children: [
 					{ path: "book", component: BookCorrectionLandingComponent },
-					{ path: "book/:isbn", component: BookCorrectionComponent },
+					{ path: "book/:correctionID/:isbn", component: BookCorrectionComponent },
 					{ path: "series", component: DataCorrectionComponent }
 				]
 			}

--- a/src/app/admin-pages/admin-routing.module.ts
+++ b/src/app/admin-pages/admin-routing.module.ts
@@ -6,6 +6,7 @@ import { HomePanelComponent } from "./home-panel/home-panel.component";
 import { UserReportComponent } from "./user-report/user-report.component";
 import { DataCorrectionComponent } from "./data-correction/data-correction.component";
 import { BookCorrectionLandingComponent } from "./book-correction-landing/book-correction-landing.component";
+import { BookCorrectionComponent } from "./book-correction/book-correction.component";
 
 const routes: Routes = [
 	{
@@ -20,6 +21,7 @@ const routes: Routes = [
 				path: "corrections",
 				children: [
 					{ path: "book", component: BookCorrectionLandingComponent },
+					{ path: "book/:isbn", component: BookCorrectionComponent },
 					{ path: "series", component: DataCorrectionComponent }
 				]
 			}

--- a/src/app/admin-pages/admin-routing.module.ts
+++ b/src/app/admin-pages/admin-routing.module.ts
@@ -3,9 +3,9 @@ import { RouterModule, Routes } from "@angular/router";
 import { IsModeratorGuard } from "../services/authentication/is-moderator.guard";
 import { LandingComponent } from "./landing/landing.component";
 import { HomePanelComponent } from "./home-panel/home-panel.component";
-import { UserManagementComponent } from "./user-management/user-management.component";
 import { UserReportComponent } from "./user-report/user-report.component";
 import { DataCorrectionComponent } from "./data-correction/data-correction.component";
+import { BookCorrectionLandingComponent } from "./book-correction-landing/book-correction-landing.component";
 
 const routes: Routes = [
 	{
@@ -15,9 +15,14 @@ const routes: Routes = [
 		children: [
 			{ path: "", component: HomePanelComponent },
 			{ path: "home", component: HomePanelComponent },
-			{ path: "data-correction", component: DataCorrectionComponent },
-			{ path: "user-management", component: UserManagementComponent },
-			{ path: "user-report", component: UserReportComponent }
+			{ path: "user-report", component: UserReportComponent },
+			{
+				path: "corrections",
+				children: [
+					{ path: "book", component: BookCorrectionLandingComponent },
+					{ path: "series", component: DataCorrectionComponent }
+				]
+			}
 		]
 	}
 ];

--- a/src/app/admin-pages/admin-routing.module.ts
+++ b/src/app/admin-pages/admin-routing.module.ts
@@ -21,7 +21,7 @@ const routes: Routes = [
 				path: "corrections",
 				children: [
 					{ path: "book", component: BookCorrectionLandingComponent },
-					{ path: "book/:correctionID/:isbn", component: BookCorrectionComponent },
+					{ path: "book/:isbn/:correctionID", component: BookCorrectionComponent },
 					{ path: "series", component: DataCorrectionComponent }
 				]
 			}

--- a/src/app/admin-pages/admin.module.ts
+++ b/src/app/admin-pages/admin.module.ts
@@ -8,6 +8,7 @@ import { DataCorrectionComponent } from "./data-correction/data-correction.compo
 import { UserReportComponent } from "./user-report/user-report.component";
 import { BookCorrectionLandingComponent } from "./book-correction-landing/book-correction-landing.component";
 import { MatTableModule } from "@angular/material/table";
+import { BookCorrectionComponent } from "./book-correction/book-correction.component";
 
 @NgModule({
 	declarations: [
@@ -16,7 +17,8 @@ import { MatTableModule } from "@angular/material/table";
 		UserManagementComponent,
 		DataCorrectionComponent,
 		UserReportComponent,
-		BookCorrectionLandingComponent
+		BookCorrectionLandingComponent,
+		BookCorrectionComponent
 	],
 	imports: [CommonModule, AdminRoutingModule, MatTableModule]
 })

--- a/src/app/admin-pages/admin.module.ts
+++ b/src/app/admin-pages/admin.module.ts
@@ -6,6 +6,8 @@ import { HomePanelComponent } from "./home-panel/home-panel.component";
 import { UserManagementComponent } from "./user-management/user-management.component";
 import { DataCorrectionComponent } from "./data-correction/data-correction.component";
 import { UserReportComponent } from "./user-report/user-report.component";
+import { BookCorrectionLandingComponent } from "./book-correction-landing/book-correction-landing.component";
+import { MatTableModule } from "@angular/material/table";
 
 @NgModule({
 	declarations: [
@@ -13,8 +15,9 @@ import { UserReportComponent } from "./user-report/user-report.component";
 		HomePanelComponent,
 		UserManagementComponent,
 		DataCorrectionComponent,
-		UserReportComponent
+		UserReportComponent,
+		BookCorrectionLandingComponent
 	],
-	imports: [CommonModule, AdminRoutingModule]
+	imports: [CommonModule, AdminRoutingModule, MatTableModule]
 })
 export class AdminModule {}

--- a/src/app/admin-pages/book-correction-landing/book-correction-landing.component.css
+++ b/src/app/admin-pages/book-correction-landing/book-correction-landing.component.css
@@ -1,0 +1,56 @@
+.status-tag {
+    padding: 8px;
+    border-radius: 6px;
+    width: 90px;
+    display: block;
+    text-align: center;
+}
+
+.in-progress {
+    background-color: lightgray;
+}
+
+.approved {
+    background-color: green;
+    color: white;
+}
+
+.denied {
+    background-color: red;
+    color: white;
+}
+
+.result-table-header {
+    background-color: #ECEBF3;
+    border-bottom: 2px gray solid;
+}
+
+.result-row {
+    cursor: pointer;
+    background-color: #ECEBF3;
+}
+
+.result-row:nth-child(2n) {
+    background-color: #fff;
+}
+
+.result-row:hover {
+    background-color: #0D98BA;
+}
+
+.result-table-cell > p {
+    margin: 0;
+}
+
+.no-results-hover {
+    cursor: default;
+}
+
+.no-results-hover:hover {
+    background-color: #ECEBF3;
+}
+
+.no-results {
+    text-align: center;
+    padding: 100px;
+}

--- a/src/app/admin-pages/book-correction-landing/book-correction-landing.component.html
+++ b/src/app/admin-pages/book-correction-landing/book-correction-landing.component.html
@@ -1,0 +1,43 @@
+<table *ngIf="dataSource" mat-table [dataSource]="dataSource" multiTemplateDataRows class="search-results">
+    <ng-container matColumnDef="create_date">
+        <th mat-header-cell *matHeaderCellDef>Submitted</th>
+        <td class="result-table-cell" mat-cell *matCellDef="let element">
+            <p>{{dateFormat(element.create_date)}}</p>
+        </td>
+    </ng-container>
+    <ng-container matColumnDef="isbn">
+        <th mat-header-cell *matHeaderCellDef>ISBN</th>
+        <td class="result-table-cell" mat-cell *matCellDef="let element">
+            <p>{{element.isbn}}</p>
+        </td>
+    </ng-container>
+    <ng-container matColumnDef="title">
+        <th mat-header-cell *matHeaderCellDef>Book</th>
+        <td class="result-table-cell" mat-cell *matCellDef="let element">
+            <p>{{bookInfoTitle.get(element.isbn)}}</p>
+        </td>
+    </ng-container>
+    <ng-container matColumnDef="update_date">
+        <th mat-header-cell *matHeaderCellDef>Updated</th>
+        <td class="result-table-cell" mat-cell *matCellDef="let element">
+            <p>{{dateFormat(element.update_date)}}</p>
+        </td>
+    </ng-container>
+    <ng-container matColumnDef="approved">
+        <th mat-header-cell *matHeaderCellDef>Status</th>
+        <td class="type-col" mat-cell *matCellDef="let element">
+            <span class="status-tag" [ngClass]="determineStatusCSS(element)">{{determineStatus(element)}}</span>
+        </td>
+    </ng-container>
+    <tr mat-header-row *matHeaderRowDef="displayedColumns" class="result-table-header"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns" class="result-row" (click)="goToCorrection(row.correction_id, row.isbn)"></tr>
+    <tr class="mat-row result-row no-results-hover" *matNoDataRow>
+        <td class="mat-cell" [attr.colspan]="displayedColumns.length">
+            <strong>
+                <p class="no-results">
+                    No corrections availible to review...
+                </p>
+            </strong>
+        </td>
+    </tr>
+</table>

--- a/src/app/admin-pages/book-correction-landing/book-correction-landing.component.spec.ts
+++ b/src/app/admin-pages/book-correction-landing/book-correction-landing.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+
+import { BookCorrectionLandingComponent } from "./book-correction-landing.component";
+
+describe("BookCorrectionLandingComponent", () => {
+	let component: BookCorrectionLandingComponent;
+	let fixture: ComponentFixture<BookCorrectionLandingComponent>;
+
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+			declarations: [BookCorrectionLandingComponent]
+		}).compileComponents();
+	});
+
+	beforeEach(() => {
+		fixture = TestBed.createComponent(BookCorrectionLandingComponent);
+		component = fixture.componentInstance;
+		fixture.detectChanges();
+	});
+
+	it("should create", () => {
+		expect(component).toBeTruthy();
+	});
+});

--- a/src/app/admin-pages/book-correction-landing/book-correction-landing.component.ts
+++ b/src/app/admin-pages/book-correction-landing/book-correction-landing.component.ts
@@ -1,0 +1,70 @@
+import { Component } from "@angular/core";
+import { MatTableDataSource } from "@angular/material/table";
+import { UtilitiesService } from "src/app/services/utilities.service";
+import { MynewormAPIService } from "src/app/services/myneworm-api.service";
+import { ActivatedRoute, Router } from "@angular/router";
+import { BookCorrectionDisplayEntry } from "src/app/models/BookCorrection";
+
+@Component({
+	selector: "book-correction-landing",
+	templateUrl: "./book-correction-landing.component.html",
+	styleUrls: ["./book-correction-landing.component.css"]
+})
+export class BookCorrectionLandingComponent {
+	displayedColumns = ["isbn", "title", "create_date", "update_date", "approved"];
+	public dataSource: MatTableDataSource<BookCorrectionDisplayEntry> =
+		new MatTableDataSource<BookCorrectionDisplayEntry>();
+	bookInfoTitle: Map<number, string> = new Map<number, string>();
+
+	constructor(
+		public utilities: UtilitiesService,
+		private service: MynewormAPIService,
+		private router: Router,
+		private route: ActivatedRoute
+	) {
+		this.dataSource = new MatTableDataSource<BookCorrectionDisplayEntry>();
+	}
+
+	getBookInfo(isbn: number) {
+		this.service.getByISBN(isbn.toString()).subscribe((data) => {
+			if (data === null) {
+				this.bookInfoTitle.set(isbn, "Unknown Entry");
+			} else {
+				this.bookInfoTitle.set(
+					isbn,
+					`${data.title} (${this.utilities.formatReadable(data.format_name)}, ${this.utilities.formatReadable(
+						data.book_type_name
+					)})`
+				);
+			}
+		});
+	}
+
+	dateFormat(date: string) {
+		return this.utilities.APIDateFormatter(new Date(date));
+	}
+
+	determineStatus(element: BookCorrectionDisplayEntry) {
+		if (element.approved) {
+			return "Approved";
+		}
+		if (element.approver_id && !element.approved) {
+			return "Denied";
+		}
+		return "In Progress";
+	}
+
+	determineStatusCSS(element: BookCorrectionDisplayEntry) {
+		if (element.approved) {
+			return "approved";
+		}
+		if (element.approver_id && !element.approved) {
+			return "denied";
+		}
+		return "in-progress";
+	}
+
+	goToCorrection(correctionID: string, isbn: string) {
+		this.router.navigate([isbn, correctionID], { relativeTo: this.route });
+	}
+}

--- a/src/app/admin-pages/book-correction-landing/book-correction-landing.component.ts
+++ b/src/app/admin-pages/book-correction-landing/book-correction-landing.component.ts
@@ -4,6 +4,7 @@ import { UtilitiesService } from "src/app/services/utilities.service";
 import { MynewormAPIService } from "src/app/services/myneworm-api.service";
 import { ActivatedRoute, Router } from "@angular/router";
 import { BookCorrectionDisplayEntry } from "src/app/models/BookCorrection";
+import { MynewormAdminService } from "src/app/services/myneworm-admin.service";
 
 @Component({
 	selector: "book-correction-landing",
@@ -12,17 +13,19 @@ import { BookCorrectionDisplayEntry } from "src/app/models/BookCorrection";
 })
 export class BookCorrectionLandingComponent {
 	displayedColumns = ["isbn", "title", "create_date", "update_date", "approved"];
-	public dataSource: MatTableDataSource<BookCorrectionDisplayEntry> =
-		new MatTableDataSource<BookCorrectionDisplayEntry>();
+	public dataSource: MatTableDataSource<BookCorrectionDisplayEntry>;
 	bookInfoTitle: Map<number, string> = new Map<number, string>();
 
 	constructor(
 		public utilities: UtilitiesService,
 		private service: MynewormAPIService,
+		private adminService: MynewormAdminService,
 		private router: Router,
 		private route: ActivatedRoute
 	) {
-		this.dataSource = new MatTableDataSource<BookCorrectionDisplayEntry>();
+		this.adminService.getAllBookCorrections().subscribe((data) => {
+			this.dataSource = new MatTableDataSource<BookCorrectionDisplayEntry>(data);
+		});
 	}
 
 	getBookInfo(isbn: number) {

--- a/src/app/admin-pages/book-correction/book-correction.component.html
+++ b/src/app/admin-pages/book-correction/book-correction.component.html
@@ -1,0 +1,3 @@
+<h1>Under Construction! Coming Soon!</h1>
+
+<a class="btn btn-lg myneworm-btn" role="button" (click)="returnPrevPage()">Go Back</a>

--- a/src/app/admin-pages/book-correction/book-correction.component.spec.ts
+++ b/src/app/admin-pages/book-correction/book-correction.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+
+import { BookCorrectionComponent } from "./book-correction.component";
+
+describe("BookCorrectionComponent", () => {
+	let component: BookCorrectionComponent;
+	let fixture: ComponentFixture<BookCorrectionComponent>;
+
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+			declarations: [BookCorrectionComponent]
+		}).compileComponents();
+	});
+
+	beforeEach(() => {
+		fixture = TestBed.createComponent(BookCorrectionComponent);
+		component = fixture.componentInstance;
+		fixture.detectChanges();
+	});
+
+	it("should create", () => {
+		expect(component).toBeTruthy();
+	});
+});

--- a/src/app/admin-pages/book-correction/book-correction.component.ts
+++ b/src/app/admin-pages/book-correction/book-correction.component.ts
@@ -1,0 +1,40 @@
+import { Component } from "@angular/core";
+import { Location } from "@angular/common";
+import { ActivatedRoute, Router } from "@angular/router";
+import { MynewormAPIService } from "src/app/services/myneworm-api.service";
+import { BookData } from "src/app/models/bookData";
+import { BookCorrectionEntry } from "src/app/models/BookCorrection";
+
+@Component({
+	selector: "book-correction",
+	templateUrl: "./book-correction.component.html",
+	styleUrls: ["./book-correction.component.css"]
+})
+export class BookCorrectionComponent {
+	bookData: BookData;
+	correctionData: BookCorrectionEntry;
+
+	constructor(
+		private service: MynewormAPIService,
+		private location: Location,
+		private route: ActivatedRoute,
+		private router: Router
+	) {}
+
+	ngOnInit() {
+		this.route.params.subscribe((data) => {
+			// use correction ID to grab correction entry
+			this.service.getByISBN(data.isbn).subscribe((bookInfo) => {
+				if (!bookInfo) {
+					return;
+				}
+
+				this.bookData = bookInfo;
+			});
+		});
+	}
+
+	returnPrevPage() {
+		this.location.back();
+	}
+}

--- a/src/app/admin-pages/landing/landing.component.css
+++ b/src/app/admin-pages/landing/landing.component.css
@@ -1,29 +1,39 @@
-.admin-side-nav {
+.admin-drawer {
     display: flex;
     flex-direction: column;
     align-items: center;
+    margin-top: 32px;
 }
 
-.admin-side-nav > h2 {
-    font-size: xx-large;
-}
-
-.admin-side-nav > a {
+.admin-drawer > a {
     display: flex;
     text-decoration: none;
     color: #1F2232;
-    width: 80%;
+    width: 90%;
     justify-content: center;
-    font-size: large;
-    border-bottom: 1px #1f2232 solid;
-    padding: 12px 0px;
-    margin: 10px 0px;
 }
 
-.admin-side-nav > a:hover {
-    color: #ECEBF3;
-    background-color: #0D98BA;
+.admin-drawer-item:hover, .admin-drawer-item-active {
+    background-color: rgb(13, 152, 186, 0.7);
     border-radius: 6px;
+}
+
+.admin-drawer-item {
+    font-size: large;
+    padding: 20px 4px;
+    margin: 2px 0px;
+    width: 100%;
+    text-align: center;
+}
+
+.admin-drawer-header {
+    border-top: 2px solid #1f2232;
+    width: 100%;
+    text-align: left;
+    padding-left: 20px;
+    font-size: larger;
+    padding-top: 10px;
+    margin-top: 20px;
 }
 
 .admin-content {

--- a/src/app/admin-pages/landing/landing.component.html
+++ b/src/app/admin-pages/landing/landing.component.html
@@ -1,11 +1,21 @@
 <div class="row">
-    <aside class="col-3 admin-side-nav">
-        <a routerLink="./home">Dashboard</a>
-        <a routerLink="./data-correction" aria-disabled="true" tabindex="-1">Data Corrections</a>
-        <a routerLink="./user-management" aria-disabled="true" tabindex="-1">User Management</a>
-        <a routerLink="./user-report" aria-disabled="true" tabindex="-1">User Reports</a>
+    <aside class="col-2 admin-drawer">
+        <a routerLink="./home" [routerLinkActive]="['admin-drawer-item-active']">
+            <span class="admin-drawer-item">Dashboard</span>
+        </a>
+        <span class="admin-drawer-header">Data Corrections</span>
+        <a routerLink="./corrections/book" [routerLinkActive]="['admin-drawer-item-active']" aria-disabled="true" tabindex="-1">
+            <span class="admin-drawer-item">Books</span>
+        </a>
+        <a routerLink="./corrections/series" [routerLinkActive]="['admin-drawer-item-active']" aria-disabled="true" tabindex="-1">
+            <span class="admin-drawer-item">Series</span>
+        </a>
+        <span class="admin-drawer-header">User Management</span>
+        <a routerLink="./user-report" [routerLinkActive]="['admin-drawer-item-active']" aria-disabled="true" tabindex="-1">
+            <span class="admin-drawer-item">Reports</span>
+        </a>
     </aside>
-    <main class="col-9">
+    <main class="col-10">
         <div class="admin-content">
             <router-outlet></router-outlet>
         </div>        

--- a/src/app/models/BookCorrection.ts
+++ b/src/app/models/BookCorrection.ts
@@ -1,0 +1,23 @@
+export interface BookCorrectionEntry {
+	correction_id: number;
+	isbn: number;
+	title?: string;
+	description?: string;
+	cover_url?: string;
+	format_name?: string;
+	book_type?: string;
+	release_date?: Date;
+	publisher_id?: number;
+	series_id?: number;
+	comment?: string;
+	create_date: string;
+	update_date: string;
+	approved: boolean;
+	mod_note?: string;
+	submitter_id: number;
+	approver_id?: number;
+}
+
+export interface BookCorrectionDisplayEntry extends BookCorrectionEntry {
+	entry_title?: string | null;
+}

--- a/src/app/services/myneworm-admin.service.spec.ts
+++ b/src/app/services/myneworm-admin.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from "@angular/core/testing";
+
+import { MynewormAdminService } from "./myneworm-admin.service";
+
+describe("MynewormAdminService", () => {
+	let service: MynewormAdminService;
+
+	beforeEach(() => {
+		TestBed.configureTestingModule({});
+		service = TestBed.inject(MynewormAdminService);
+	});
+
+	it("should be created", () => {
+		expect(service).toBeTruthy();
+	});
+});

--- a/src/app/services/myneworm-admin.service.ts
+++ b/src/app/services/myneworm-admin.service.ts
@@ -1,0 +1,42 @@
+import { Injectable } from "@angular/core";
+import { AdminModule } from "../admin-pages/admin.module";
+import { HttpClient } from "@angular/common/http";
+import { ToastService } from "./toast.service";
+import { catchError, of } from "rxjs";
+import { environment } from "src/environments/environment";
+
+@Injectable({
+	providedIn: AdminModule
+})
+export class MynewormAdminService {
+	constructor(
+		private http: HttpClient,
+		private toastService: ToastService
+	) {}
+
+	getAllBookCorrections() {
+		return this.http.get(`${environment.API_ADDRESS}/corrections/book`);
+	}
+
+	getBookCorrection(correctionID: string) {
+		return this.http.get(`${environment.API_ADDRESS}/corrections/book/${correctionID}`);
+	}
+
+	approveBookCorrection(correctionID: string) {
+		return this.http.patch(`${environment.API_ADDRESS}/corrections/book/approve/${correctionID}`, {}).pipe(
+			catchError((err: any) => {
+				this.toastService.sendError("Caught server error. API has logged the issue.");
+				return of(null);
+			})
+		);
+	}
+
+	denyBookCorrection(correctionID: string) {
+		return this.http.patch(`${environment.API_ADDRESS}/corrections/book/deny/${correctionID}`, {}).pipe(
+			catchError((err: any) => {
+				this.toastService.sendError("Caught server error. API has logged the issue.");
+				return of(null);
+			})
+		);
+	}
+}

--- a/src/app/services/myneworm-admin.service.ts
+++ b/src/app/services/myneworm-admin.service.ts
@@ -1,12 +1,12 @@
 import { Injectable } from "@angular/core";
-import { AdminModule } from "../admin-pages/admin.module";
 import { HttpClient } from "@angular/common/http";
 import { ToastService } from "./toast.service";
 import { catchError, of } from "rxjs";
 import { environment } from "src/environments/environment";
+import { BookCorrectionDisplayEntry, BookCorrectionEntry } from "../models/BookCorrection";
 
 @Injectable({
-	providedIn: AdminModule
+	providedIn: "root"
 })
 export class MynewormAdminService {
 	constructor(
@@ -15,11 +15,11 @@ export class MynewormAdminService {
 	) {}
 
 	getAllBookCorrections() {
-		return this.http.get(`${environment.API_ADDRESS}/corrections/book`);
+		return this.http.get<BookCorrectionDisplayEntry[]>(`${environment.API_ADDRESS}/corrections/book`);
 	}
 
 	getBookCorrection(correctionID: string) {
-		return this.http.get(`${environment.API_ADDRESS}/corrections/book/${correctionID}`);
+		return this.http.get<BookCorrectionEntry>(`${environment.API_ADDRESS}/corrections/book/${correctionID}`);
 	}
 
 	approveBookCorrection(correctionID: string) {


### PR DESCRIPTION
<!-- 
    Thank you for contributing! 
    If you have not already, please review the contribution guidelines before submitting:
    https://github.com/Butterstroke/Myneworm/tree/master/.github/CONTRIBUTING.md
-->

## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Creates the pages needed for book correction reviews and designed the layout of the list page.

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

Designed the table to display various correction submissions for book entries. Each row is clickable and sends the moderator user into a page that will display the details and changes suggested. Routes for these submissions have been changed from `data-correction` to `corrections/book/:isbn/:correctionID` and sets up a similar pathing for series corrections (planned for a separate epic).

Implementation of working interactions (ie: viewing existing entries and filtering) were broken from this ticket and made into two separate tickets to handle the complexity of the task better.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->

Ticket: Internal#938
Created tickets: Internal#942 & Internal#943