### PR TITLE
[Feature/867] Added Cancel Button & Update Styling on ListEntryModal

### DIFF
--- a/src/app/shared/list-entry-modal/list-entry-modal.component.css
+++ b/src/app/shared/list-entry-modal/list-entry-modal.component.css
@@ -1,4 +1,6 @@
 .list-entry-modal {
+    display: flex;
+    flex-direction: column;
     padding: 2% 3%;
     height: 100%;
     background-color: #ECEBF3;
@@ -7,6 +9,25 @@
 
 .modal-label {
     font-size: 0.941vw;
+}
+
+.close-wrapper {
+    height: inherit;
+}
+
+.modal-close {
+    font-size: larger;
+    color: gray;
+    transition: none;
+    border: 0;
+    padding: 0;
+    height: 36px;
+    width: 36px;
+}
+
+.modal-close:hover, .modal-close:active {
+    color: #ECEBF3 !important;
+    background-color: #0D98BA !important;
 }
 
 @media screen and (max-width: 1024px) {
@@ -109,4 +130,25 @@
 
 .modal-input-textarea {
     max-height: calc(46vh - 315px);
+}
+
+@media screen and (max-width: 768px) {
+    .col-6 {
+        width: 100%;
+    }
+    .modal-label {
+        font-size: medium;
+    }
+    .form-group:nth-child(n+2) {
+        margin-top: 0;
+    }
+}
+
+@media screen and (max-width: 425px) {
+    .modal-footer {
+        justify-content: space-evenly;
+    }
+    .modal-action {
+        margin-right: 0;
+    }    
 }

--- a/src/app/shared/list-entry-modal/list-entry-modal.component.html
+++ b/src/app/shared/list-entry-modal/list-entry-modal.component.html
@@ -1,6 +1,9 @@
 <div class="list-entry-modal">
     <header class="modal-header">
         <h2>{{bookData.title}}</h2>
+        <div class="close-wrapper">
+            <button type="button" class="btn modal-close" (click)="close()">X</button>
+        </div>        
     </header>
     <div class="modal-content">
         <div class="row modal-row">


### PR DESCRIPTION
<!-- 
    Thank you for contributing! 
    If you have not already, please review the contribution guidelines before submitting:
    https://github.com/Butterstroke/Myneworm/tree/master/.github/CONTRIBUTING.md
-->

## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Adds a cancel button on the top of the ListEntryModal menu to close without saving. Also added a couple of CSS styling rules to improve the modal experience on tablets and mobile devices.

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

Added an X button to the header of the modal and then styled it as needed. Then, added a click event to trigger the `close()` function.

For styling, I used the brower's devtools to mimic a mobile & tablet width. Then, added styling based on what I was shown until the modal looked slightly better than the previous version.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->

Internal#867