### PR TITLE
[Feature/939] Updated Styling to Match Support Page for FAQ Page

### DIFF
--- a/src/app/pages/faq/faq.component.css
+++ b/src/app/pages/faq/faq.component.css
@@ -1,11 +1,11 @@
 .faq-header {
-    width: fit-content;
-    margin-bottom: 16px;
+    margin-top: 20px;
+    margin-bottom: 20px;
+    border-bottom: 2px black solid;
 }
 
-.faq-header:after
-{
-    content:' ';
-    display:block;
-    border:2px solid black;
+.faq-component {
+    display: flex;
+    flex-direction: column;
+    margin: 0% 20%;
 }

--- a/src/app/pages/faq/faq.component.html
+++ b/src/app/pages/faq/faq.component.html
@@ -1,7 +1,9 @@
-<div *ngFor="let section of faqData | keyvalue">
-    <h3 class="faq-header">{{section.key}}</h3>
-    <div *ngFor="let question of section.value; let i = index">
-        <h4>Q: {{question[0]}}</h4>
-        <p>A: <span [innerHTML]="question[1]"></span></p>
+<div class="faq-component">
+    <div *ngFor="let section of faqData | keyvalue">
+        <h3 class="faq-header">{{section.key}}</h3>
+        <div *ngFor="let question of section.value; let i = index">
+            <h4>{{question[0]}}</h4>
+            <p><span [innerHTML]="question[1]"></span></p>
+        </div>
     </div>
 </div>

--- a/src/app/pages/faq/faqData.ts
+++ b/src/app/pages/faq/faqData.ts
@@ -11,18 +11,23 @@ export const FAQData = {
 	Database: [
 		[
 			"What is accepted in Myneworm's Database?",
-			`We currently accept any English translations for manga and light novels based on our database guidelines. You can find the details on
-			our guideline page <a href='/guidelines'>here</a>.`
+			`We accept any English translations for manga, light novels, and their adjacent book-based media that meets our database guidelines. Details on 
+			what we define as acceptable can be found on our <a href='/guidelines'>database guidelines</a> page.`
 		],
 		[
 			"Why can't I find X title?",
-			`As stated previously, we currently track English translations. If a title does not meet our guidelines, then we do not track it. However,
-			if the title meets our guidelines and isn't on the site yet, we might have missed it! You can submit a data correction form
-			<a href='/faq'>here</a>. A moderator will review and potentially approve your changes!`
+			`Depending on the title, we might have missed it! Please review our <a href='/guidelines'>database guidelines</a> to double check if 
+			it qualifies. If it does, <s>submit a data correction form</s> reach out to a Myneworm moderator to review and potentially approve your changes!`
 		],
 		[
 			"Why aren't J-Novel Club Parts tracked",
-			"While the J-Novel parts are English translated, they do not have ISBN numbers or a whole book. Thus don't meet the minimum requirements."
+			"J-Novel parts do not contain ISBN numbers or are an entire book and are ineligible."
+		]
+	],
+	Lists: [
+		[
+			"How do I add/remove books from my wishlist?",
+			"To add a book to your wishlist, you'll need to mark the book as 'Wanted' in the owner status. To remove the book, change the owner status so that 'Wanted' is not selected."
 		]
 	],
 	"Other Questions": [


### PR DESCRIPTION
<!-- 
    Thank you for contributing! 
    If you have not already, please review the contribution guidelines before submitting:
    https://github.com/Butterstroke/Myneworm/tree/master/.github/CONTRIBUTING.md
-->

## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Updates the styling on the FAQ page to match the styling used in the support page.

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

Referred to the support page to identify which styling rules to apply to the FAQ page. Then, added a div wrapper to apply the width and removed some redundant styling with the headers to create a matching style layout.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->

Internal#939