### PR TITLE
[Fix/945] Fixed Display Issue on Start & End Dates for List Entries

### DIFF
--- a/src/app/functions/formatDateString.ts
+++ b/src/app/functions/formatDateString.ts
@@ -8,5 +8,5 @@ function zeroAdder(value: number) {
 export function formatDateString(dateInput: string) {
 	const dateObj = new Date(dateInput);
 
-	return `${zeroAdder(dateObj.getDate())}-${zeroAdder(dateObj.getMonth())}-${dateObj.getFullYear()}`;
+	return `${zeroAdder(dateObj.getDate())}-${zeroAdder(dateObj.getMonth() + 1)}-${dateObj.getFullYear()}`;
 }


### PR DESCRIPTION
<!-- 
    Thank you for contributing! 
    If you have not already, please review the contribution guidelines before submitting:
    https://github.com/Butterstroke/Myneworm/tree/master/.github/CONTRIBUTING.md
-->

## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Fixes a display issue where the start and end date months would be off by one in the list entries.

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

The issue was related to the native `getMonth` function where it returns 0-11. Updated the `formatDateString` function to add one to `getMonth` to return a 1-12 range.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->
Internal#945